### PR TITLE
Port driver implementation from PoC

### DIFF
--- a/config/environment
+++ b/config/environment
@@ -20,6 +20,7 @@ LAMBDA_MAPPER_FUNCTION_NAME="dcp-matrix-service-mapper-${DEPLOYMENT_STAGE}"
 LAMBDA_WORKER_FUNCTION_NAME="dcp-matrix-service-worker-${DEPLOYMENT_STAGE}"
 LAMBDA_REDUCER_FUNCTION_NAME="dcp-matrix-service-reducer-${DEPLOYMENT_STAGE}"
 DYNAMO_STATE_TABLE_NAME="dcp-matrix-service-state-table-${DEPLOYMENT_STAGE}"
+DYNAMO_OUTPUT_TABLE_NAME="dcp-matrix-service-output-table-${DEPLOYMENT_STAGE}"
 set +a
 
 echo "DEPLOYMENT STAGE IS \"${DEPLOYMENT_STAGE}\""

--- a/daemons/filter_merge/app.py
+++ b/daemons/filter_merge/app.py
@@ -11,14 +11,17 @@ worker  - Apply user-defined filter query on chunk, write partial results to S3
 reducer - Combine partial results into final .zarr file in S3, return S3 location
 """
 
-from matrix.lambdas.filter_merge.driver import driver
+from matrix.lambdas.filter_merge.driver import Driver
 from matrix.lambdas.filter_merge.mapper import mapper
 from matrix.lambdas.filter_merge.worker import worker
 from matrix.lambdas.filter_merge.reducer import reducer
 
 
-def driver_handler():
-    driver()
+def driver_handler(event, context):
+    # TODO: better error handling
+    assert 'request_id' in event and 'bundle_fqids' in event and 'format' in event
+    driver = Driver()
+    driver.run(event['request_id'], event['bundle_fqids'], event['format'])
 
 
 def mapper_handler():

--- a/matrix/common/constants.py
+++ b/matrix/common/constants.py
@@ -9,5 +9,5 @@ class MatrixFormat(Enum):
 
 class MatrixRequestStatus(Enum):
     COMPLETE = "Complete"
-    IN_PROGRESS = "In progress"
+    IN_PROGRESS = "In Progress"
     FAILED = "Failed"

--- a/matrix/common/dynamo_handler.py
+++ b/matrix/common/dynamo_handler.py
@@ -17,15 +17,24 @@ class StateTableField(Enum):
     COMPLETED_REDUCER_EXECUTIONS = "CompletedReducerExecutions"
 
 
+class OutputTableField(Enum):
+    """
+    Field names for Output table in DynamoDB.
+    """
+    REQUEST_ID = "RequestId"
+    ROW_COUNT = "RowCount"
+
+
 class DynamoHandler:
     """
     Interface for interacting with DynamoDB Tables.
     """
     def __init__(self):
         self._dynamo = boto3.resource("dynamodb", region_name=os.environ['AWS_DEFAULT_REGION'])
-        self._state_table = self._dynamo.Table(os.environ['DYNAMO_STATE_TABLE_NAME'])
+        self._state_table = self._dynamo.Table(os.getenv("DYNAMO_STATE_TABLE_NAME"))
+        self._output_table = self._dynamo.Table(os.getenv("DYNAMO_OUTPUT_TABLE_NAME"))
 
-    def put_state_item(self, request_id, num_bundles):
+    def create_state_table_entry(self, request_id: str, num_bundles: int):
         """
         Put a new item in the DynamoDB table responsible for tracking task execution states and
         counts for a specified job.
@@ -41,6 +50,18 @@ class DynamoHandler:
                 StateTableField.EXPECTED_MAPPER_EXECUTIONS.value: num_bundles,
                 StateTableField.COMPLETED_MAPPER_EXECUTIONS.value: 0,
                 StateTableField.EXPECTED_REDUCER_EXECUTIONS.value: 1,
-                StateTableField.COMPLETED_REDUCER_EXECUTIONS.value: 0
+                StateTableField.COMPLETED_REDUCER_EXECUTIONS.value: 0,
+            }
+        )
+
+    def create_output_table_entry(self, request_id: str):
+        """
+        Put a new item in the DynamoDB Table responsible for counting output rows
+        :param request_id: UUID identifying a filter merge job request.
+        """
+        self._output_table.put_item(
+            Item={
+                OutputTableField.REQUEST_ID.value: request_id,
+                OutputTableField.ROW_COUNT.value: 0,
             }
         )

--- a/matrix/common/dynamo_handler.py
+++ b/matrix/common/dynamo_handler.py
@@ -25,9 +25,9 @@ class DynamoHandler:
         self._dynamo = boto3.resource("dynamodb", region_name=os.environ['AWS_DEFAULT_REGION'])
         self._state_table = self._dynamo.Table(os.environ['DYNAMO_STATE_TABLE_NAME'])
 
-    def init_state_table(self, request_id, num_bundles):
+    def put_state_item(self, request_id, num_bundles):
         """
-        Initialize the DynamoDB table responsible for tracking task execution states and
+        Put a new item in the DynamoDB table responsible for tracking task execution states and
         counts for a specified job.
 
         :param request_id: UUID identifying a filter merge job request.

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -1,47 +1,61 @@
-import json
-import os
 import requests
-
-import boto3
+import uuid
 
 from ...common.constants import MatrixFormat
+from ...common.constants import MatrixRequestStatus
+from ...common.lambda_handler import LambdaHandler
+from ...common.lambda_handler import LambdaName
 
-LAMBDA_CLIENT = boto3.client("lambda",
-                             region_name=os.environ['AWS_DEFAULT_REGION'])
 
-
-def post_matrix(body):
+def post_matrix(body: dict):
     has_ids = 'bundle_fqids' in body
     has_url = 'bundle_fqids_url' in body
 
     format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
 
-    # validate input parameters
+    # Validate input parameters
     if not (has_ids or has_url):
         return {
-                   'code': requests.codes.bad_request,
-                   'message': "Missing required parameter. "
-                              "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
-                              "Visit https://matrix.dev.data.humancellatlas.org for more information."
-               }, requests.codes.bad_request
+            'code': requests.codes.bad_request,
+            'message': "Missing required parameter. "
+                       "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
+                       "Visit https://matrix.dev.data.humancellatlas.org for more information."
+        }, requests.codes.bad_request
 
     if has_ids and has_url:
         return {
-                   'code': requests.codes.bad_request,
-                   'message': "Invalid parameters supplied. "
-                              "Must supply either one of `bundle_fqids` or `bundle_fqids_url`. "
-                              "Visit https://matrix.dev.data.humancellatlas.org for more information."
-               }, requests.codes.bad_request
+            'code': requests.codes.bad_request,
+            'message': "Invalid parameters supplied. "
+                       "Must supply either one of `bundle_fqids` or `bundle_fqids_url`. "
+                       "Visit https://matrix.dev.data.humancellatlas.org for more information."
+        }, requests.codes.bad_request
 
-    LAMBDA_CLIENT.invoke(
-        FunctionName=os.environ['DRIVER_FN_NAME'],
-        InvocationType="Event",
-        Payload=json.dumps(body).encode(),
-    )
-    return "post_matrix", requests.codes.ok
+    # TODO: test when URL param is supported
+    if has_url:
+        response = requests.get(body['bundle_fqids_url'])
+        bundle_fqids = [b.strip() for b in response.text.split()]
+    else:
+        bundle_fqids = body['bundle_fqids']
+
+    request_id = str(uuid.uuid4())
+    driver_payload = {
+        'request_id': request_id,
+        'bundle_fqids': bundle_fqids,
+        'format': format,
+    }
+    lambda_handler = LambdaHandler()
+    lambda_handler.invoke(LambdaName.DRIVER, driver_payload)
+
+    return {'request_id': request_id,
+            'status': MatrixRequestStatus.IN_PROGRESS.value,
+            'key': "",
+            'eta': "",
+            'message': "Job started.",
+            'links': [],
+            }, requests.codes.accepted
 
 
-def get_matrix(request_id):
+def get_matrix(request_id: str):
     return {'request_id': request_id,
             'status': "In Progress",
             'key': "sample key",

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -14,19 +14,19 @@ def post_matrix(body: dict):
     format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
 
     # Validate input parameters
-    if not (has_ids or has_url):
-        return {
-            'code': requests.codes.bad_request,
-            'message': "Missing required parameter. "
-                       "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
-                       "Visit https://matrix.dev.data.humancellatlas.org for more information."
-        }, requests.codes.bad_request
-
     if has_ids and has_url:
         return {
             'code': requests.codes.bad_request,
             'message': "Invalid parameters supplied. "
                        "Must supply either one of `bundle_fqids` or `bundle_fqids_url`. "
+                       "Visit https://matrix.dev.data.humancellatlas.org for more information."
+        }, requests.codes.bad_request
+
+    if not has_ids and not has_url:
+        return {
+            'code': requests.codes.bad_request,
+            'message': "Missing required parameter. "
+                       "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
                        "Visit https://matrix.dev.data.humancellatlas.org for more information."
         }, requests.codes.bad_request
 

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -4,11 +4,35 @@ import requests
 
 import boto3
 
+from ...common.constants import MatrixFormat
+
 LAMBDA_CLIENT = boto3.client("lambda",
                              region_name=os.environ['AWS_DEFAULT_REGION'])
 
 
 def post_matrix(body):
+    has_ids = 'bundle_fqids' in body
+    has_url = 'bundle_fqids_url' in body
+
+    format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
+
+    # validate input parameters
+    if not (has_ids or has_url):
+        return {
+                   'code': requests.codes.bad_request,
+                   'message': "Missing required parameter. "
+                              "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
+                              "Visit https://matrix.dev.data.humancellatlas.org for more information."
+               }, requests.codes.bad_request
+
+    if has_ids and has_url:
+        return {
+                   'code': requests.codes.bad_request,
+                   'message': "Invalid parameters supplied. "
+                              "Must supply either one of `bundle_fqids` or `bundle_fqids_url`. "
+                              "Visit https://matrix.dev.data.humancellatlas.org for more information."
+               }, requests.codes.bad_request
+
     LAMBDA_CLIENT.invoke(
         FunctionName=os.environ['DRIVER_FN_NAME'],
         InvocationType="Event",

--- a/matrix/lambdas/filter_merge/driver.py
+++ b/matrix/lambdas/filter_merge/driver.py
@@ -1,2 +1,33 @@
-def driver():
-    pass
+import typing
+
+from ...common.dynamo_handler import DynamoHandler
+from ...common.lambda_handler import LambdaHandler
+from ...common.lambda_handler import LambdaName
+
+
+class Driver:
+    """
+    The first task in a distributed filter merge job.
+    """
+    def __init__(self):
+        self.lambda_handler = LambdaHandler()
+        self.dynamo_handler = DynamoHandler()
+
+    def run(self, request_id: str, bundle_fqids: typing.List[str], format: str):
+        """
+        Initialize a filter merge job and spawn a mapper task for each bundle_fqid.
+
+        :param request_id: Filter merge job request ID
+        :param bundle_fqids: List of bundle fqids to be queried on
+        :param format: MatrixFormat file format of expression matrices
+        """
+        self.dynamo_handler.init_state_table(request_id, len(bundle_fqids))
+
+        for fqid in bundle_fqids:
+            mapper_payload = {
+                'request_id': request_id,
+                'bundle_fqid': fqid,
+                'format': format,
+            }
+
+            self.lambda_handler.invoke(LambdaName.MAPPER, mapper_payload)

--- a/matrix/lambdas/filter_merge/driver.py
+++ b/matrix/lambdas/filter_merge/driver.py
@@ -21,7 +21,7 @@ class Driver:
         :param bundle_fqids: List of bundle fqids to be queried on
         :param format: MatrixFormat file format of expression matrices
         """
-        self.dynamo_handler.init_state_table(request_id, len(bundle_fqids))
+        self.dynamo_handler.put_state_item(request_id, len(bundle_fqids))
 
         for fqid in bundle_fqids:
             mapper_payload = {

--- a/matrix/lambdas/filter_merge/driver.py
+++ b/matrix/lambdas/filter_merge/driver.py
@@ -21,7 +21,8 @@ class Driver:
         :param bundle_fqids: List of bundle fqids to be queried on
         :param format: MatrixFormat file format of expression matrices
         """
-        self.dynamo_handler.put_state_item(request_id, len(bundle_fqids))
+        self.dynamo_handler.create_state_table_entry(request_id, len(bundle_fqids))
+        self.dynamo_handler.create_output_table_entry(request_id)
 
         for fqid in bundle_fqids:
             mapper_payload = {

--- a/terraform/modules/matrix-service/lambdas/driver_lambda.tf
+++ b/terraform/modules/matrix-service/lambdas/driver_lambda.tf
@@ -70,6 +70,7 @@ resource "aws_lambda_function" "matrix_service_driver_lambda" {
         DEPLOYMENT_STAGE = "${var.deployment_stage}"
         LAMBDA_MAPPER_FUNCTION_NAME="dcp-matrix-service-mapper-${var.deployment_stage}"
         DYNAMO_STATE_TABLE_NAME="dcp-matrix-service-state-table-${var.deployment_stage}"
+        DYNAMO_OUTPUT_TABLE_NAME="dcp-matrix-service-output-table-${var.deployment_stage}"
     }
   }
 }

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -10,6 +10,7 @@ os.environ['AWS_ACCESS_KEY_ID'] = "ak"
 os.environ['AWS_SECRET_ACCESS_KEY'] = "sk"
 os.environ['LAMBDA_DRIVER_FUNCTION_NAME'] = f"dcp-matrix-service-driver-{os.environ['DEPLOYMENT_STAGE']}"
 os.environ['DYNAMO_STATE_TABLE_NAME'] = f"dcp-matrix-service-state-table-{os.environ['DEPLOYMENT_STAGE']}"
+os.environ['DYNAMO_OUTPUT_TABLE_NAME'] = f"dcp-matrix-service-output-table-{os.environ['DEPLOYMENT_STAGE']}"
 
 
 class MatrixTestCaseUsingMockAWS(unittest.TestCase):
@@ -19,3 +20,47 @@ class MatrixTestCaseUsingMockAWS(unittest.TestCase):
 
     def tearDown(self):
         self.dynamo_mock.stop()
+
+    @staticmethod
+    def create_test_state_table(dynamo):
+        dynamo.create_table(
+            TableName=os.environ['DYNAMO_STATE_TABLE_NAME'],
+            KeySchema=[
+                {
+                    'AttributeName': "RequestId",
+                    'KeyType': "HASH",
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': "RequestId",
+                    'AttributeType': "S",
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 25,
+                'WriteCapacityUnits': 25,
+            },
+        )
+
+    @staticmethod
+    def create_test_output_table(dynamo):
+        dynamo.create_table(
+            TableName=os.environ['DYNAMO_OUTPUT_TABLE_NAME'],
+            KeySchema=[
+                {
+                    'AttributeName': "RequestId",
+                    'KeyType': "HASH",
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': "RequestId",
+                    'AttributeType': "S",
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 15,
+                'WriteCapacityUnits': 15,
+            },
+        )

--- a/tests/unit/common/test_dynamo_handler.py
+++ b/tests/unit/common/test_dynamo_handler.py
@@ -5,6 +5,7 @@ import boto3
 from .. import MatrixTestCaseUsingMockAWS
 from matrix.common.dynamo_handler import DynamoHandler
 from matrix.common.dynamo_handler import StateTableField
+from matrix.common.dynamo_handler import OutputTableField
 
 
 class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
@@ -14,17 +15,20 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
     def setUp(self):
         super(TestDynamoHandler, self).setUp()
 
-        self.handler = DynamoHandler()
-        self.state_table_name = os.environ['DYNAMO_STATE_TABLE_NAME']
         self.dynamo = boto3.resource("dynamodb", region_name=os.environ['AWS_DEFAULT_REGION'])
+        self.state_table_name = os.environ['DYNAMO_STATE_TABLE_NAME']
+        self.output_table_name = os.environ['DYNAMO_OUTPUT_TABLE_NAME']
 
-        self._create_test_state_table()
+        self.create_test_state_table(self.dynamo)
+        self.create_test_output_table(self.dynamo)
 
-    def test_put_state_item(self):
+        self.handler = DynamoHandler()
+
+    def test_create_state_table_entry(self):
         request_id = "test_id"
         num_bundles = 2
 
-        self.handler.put_state_item(request_id, num_bundles)
+        self.handler.create_state_table_entry(request_id, num_bundles)
         response = self.dynamo.batch_get_item(
             RequestItems={
                 self.state_table_name: {
@@ -40,23 +44,20 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.assertEqual(entry[StateTableField.EXPECTED_MAPPER_EXECUTIONS.value], num_bundles)
         self.assertEqual(entry[StateTableField.EXPECTED_REDUCER_EXECUTIONS.value], 1)
 
-    def _create_test_state_table(self):
-        self.dynamo.create_table(
-            TableName=self.state_table_name,
-            KeySchema=[
-                {
-                    'AttributeName': "RequestId",
-                    'KeyType': "HASH",
+    def test_create_output_table_entry(self):
+        request_id = "test_id"
+
+        self.handler.create_output_table_entry(request_id)
+        response = self.dynamo.batch_get_item(
+            RequestItems={
+                self.output_table_name: {
+                    'Keys': [{'RequestId': request_id}]
                 }
-            ],
-            AttributeDefinitions=[
-                {
-                    'AttributeName': "RequestId",
-                    'AttributeType': "S",
-                }
-            ],
-            ProvisionedThroughput={
-                'ReadCapacityUnits': 25,
-                'WriteCapacityUnits': 25,
-            },
+            }
         )
+
+        self.assertEqual(len(response['Responses'][self.output_table_name]), 1)
+        entry = response['Responses'][self.output_table_name][0]
+
+        self.assertTrue(all(field.value in entry for field in OutputTableField))
+        self.assertEqual(entry[OutputTableField.ROW_COUNT.value], 0)

--- a/tests/unit/common/test_dynamo_handler.py
+++ b/tests/unit/common/test_dynamo_handler.py
@@ -18,13 +18,13 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.state_table_name = os.environ['DYNAMO_STATE_TABLE_NAME']
         self.dynamo = boto3.resource("dynamodb", region_name=os.environ['AWS_DEFAULT_REGION'])
 
-        self._create_state_table()
+        self._create_test_state_table()
 
-    def test_init_state_table(self):
+    def test_put_state_item(self):
         request_id = "test_id"
         num_bundles = 2
 
-        self.handler.init_state_table(request_id, num_bundles)
+        self.handler.put_state_item(request_id, num_bundles)
         response = self.dynamo.batch_get_item(
             RequestItems={
                 self.state_table_name: {
@@ -40,7 +40,7 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.assertEqual(entry[StateTableField.EXPECTED_MAPPER_EXECUTIONS.value], num_bundles)
         self.assertEqual(entry[StateTableField.EXPECTED_REDUCER_EXECUTIONS.value], 1)
 
-    def _create_state_table(self):
+    def _create_test_state_table(self):
         self.dynamo.create_table(
             TableName=self.state_table_name,
             KeySchema=[

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -1,7 +1,48 @@
+import requests
 import unittest
+from unittest import mock
+
+from matrix.common.constants import MatrixFormat
+from matrix.common.constants import MatrixRequestStatus
+from matrix.common.lambda_handler import LambdaName
+from matrix.lambdas.api.core import post_matrix
 
 
 class TestCore(unittest.TestCase):
+    @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
+    def test_post_matrix_with_ids_ok(self, mock_lambda_invoke):
+        bundle_fqids = ["id1", "id2"]
+        format = MatrixFormat.ZARR.value
 
-    def test_something(self):
-        pass
+        body = {
+            'bundle_fqids': bundle_fqids,
+            'format': format
+        }
+        response, code = post_matrix(body)
+        body.update({'request_id': mock.ANY})
+
+        mock_lambda_invoke.assert_called_once_with(LambdaName.DRIVER, body)
+        self.assertEqual(type(response['request_id']), str)
+        self.assertEqual(response['status'], MatrixRequestStatus.IN_PROGRESS.value)
+        self.assertEqual(code, requests.codes.accepted)
+
+    @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
+    def test_post_matrix_with_ids_and_url(self, mock_lambda_invoke):
+        bundle_fqids = ["id1", "id2"]
+        bundle_fqids_url = "test_url"
+
+        body = {
+            'bundle_fqids': bundle_fqids,
+            'bundle_fqids_url': bundle_fqids_url
+        }
+        response, code = post_matrix(body)
+
+        self.assertEqual(mock_lambda_invoke.call_count, 0)
+        self.assertEqual(code, requests.codes.bad_request)
+
+    @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
+    def test_post_matrix_without_ids_or_url(self, mock_lambda_invoke):
+        response, code = post_matrix({})
+
+        self.assertEqual(mock_lambda_invoke.call_count, 0)
+        self.assertEqual(code, requests.codes.bad_request)

--- a/tests/unit/lambdas/filter_merge/test_driver.py
+++ b/tests/unit/lambdas/filter_merge/test_driver.py
@@ -10,16 +10,16 @@ class TestDriver(unittest.TestCase):
     def setUp(self):
         self._driver = Driver()
 
-    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.init_state_table")
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.put_state_item")
     @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
-    def test_run(self, mock_lambda_invoke, mock_dynamo_init_state_table):
+    def test_run(self, mock_lambda_invoke, mock_dynamo_put_state_item):
         request_id = str(uuid.uuid4())
         bundle_fqids = ["id1", "id2"]
         format = "test_format"
 
         self._driver.run(request_id, bundle_fqids, format)
 
-        mock_dynamo_init_state_table.assert_called_once_with(request_id, len(bundle_fqids))
+        mock_dynamo_put_state_item.assert_called_once_with(request_id, len(bundle_fqids))
         mock_lambda_invoke.assert_called_with(LambdaName.MAPPER,
                                               {
                                                   'request_id': request_id,

--- a/tests/unit/lambdas/filter_merge/test_driver.py
+++ b/tests/unit/lambdas/filter_merge/test_driver.py
@@ -10,16 +10,18 @@ class TestDriver(unittest.TestCase):
     def setUp(self):
         self._driver = Driver()
 
-    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.put_state_item")
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.create_state_table_entry")
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.create_output_table_entry")
     @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
-    def test_run(self, mock_lambda_invoke, mock_dynamo_put_state_item):
+    def test_run(self, mock_lambda_invoke, mock_dynamo_create_output_table_entry, mock_dynamo_create_state_table_entry):
         request_id = str(uuid.uuid4())
         bundle_fqids = ["id1", "id2"]
         format = "test_format"
 
         self._driver.run(request_id, bundle_fqids, format)
 
-        mock_dynamo_put_state_item.assert_called_once_with(request_id, len(bundle_fqids))
+        mock_dynamo_create_state_table_entry.assert_called_once_with(request_id, len(bundle_fqids))
+        mock_dynamo_create_output_table_entry.assert_called_once_with(request_id)
         mock_lambda_invoke.assert_called_with(LambdaName.MAPPER,
                                               {
                                                   'request_id': request_id,

--- a/tests/unit/lambdas/filter_merge/test_driver.py
+++ b/tests/unit/lambdas/filter_merge/test_driver.py
@@ -1,7 +1,29 @@
 import unittest
+from unittest import mock
+import uuid
+
+from matrix.common.lambda_handler import LambdaName
+from matrix.lambdas.filter_merge.driver import Driver
 
 
 class TestDriver(unittest.TestCase):
+    def setUp(self):
+        self._driver = Driver()
 
-    def test_something(self):
-        pass
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.init_state_table")
+    @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
+    def test_run(self, mock_lambda_invoke, mock_dynamo_init_state_table):
+        request_id = str(uuid.uuid4())
+        bundle_fqids = ["id1", "id2"]
+        format = "test_format"
+
+        self._driver.run(request_id, bundle_fqids, format)
+
+        mock_dynamo_init_state_table.assert_called_once_with(request_id, len(bundle_fqids))
+        mock_lambda_invoke.assert_called_with(LambdaName.MAPPER,
+                                              {
+                                                  'request_id': request_id,
+                                                  'bundle_fqid': bundle_fqids[1],
+                                                  'format': format,
+                                              })
+        self.assertEqual(mock_lambda_invoke.call_count, len(bundle_fqids))


### PR DESCRIPTION
_Ported driver implementation from [here](https://github.com/HumanCellAtlas/table-testing/tree/master/distributed_test/filter_merge_lambda)._

Driver is the first subtask of a filter merge job. The current implementation accepts a list of bundle fqids (fully qualified id; \<uuid\>.\<version\>), verifies correct parameter usage (`bundle_fqids` or `bundle_fqid_urls`, but not both), and invokes a `Mapper` subtask for each `bundle_fqid`.