### PR TITLE
Fix Travis google_compute_engine dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 3.6
+before_install:
+- export BOTO_CONFIG=/dev/null
 install:
 - pip install -r requirements-dev.txt
 script:


### PR DESCRIPTION
Looks like a boto config is added (by Google? on Travis?) that imports `google_compute_engine`. A workaround for this is to point `BOTO_CONFIG` to something else - see [moto .travis.yml](https://github.com/spulec/moto/blob/master/.travis.yml#L25).

https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-310759657