### PR TITLE
Introduce filter string param to POST endpoint

### DIFF
--- a/daemons/driver/app.py
+++ b/daemons/driver/app.py
@@ -3,6 +3,6 @@ from matrix.lambdas.daemons.driver import Driver
 
 def driver_handler(event, context):
     # TODO: better error handling
-    assert 'request_id' in event and 'bundle_fqids' in event and 'format' in event
+    assert 'request_id' in event and 'bundle_fqids' in event and 'filter_string' in event and 'format' in event
     driver = Driver()
-    driver.run(event['request_id'], event['bundle_fqids'], event['format'])
+    driver.run(event['request_id'], event['bundle_fqids'], event['filter_string'], event['format'])

--- a/daemons/mapper/app.py
+++ b/daemons/mapper/app.py
@@ -3,6 +3,11 @@ from matrix.lambdas.daemons.mapper import Mapper
 
 def mapper_handler(event, context):
     # TODO: better error handling
-    assert "request_id" in event and "bundle_uuid" in event and "bundle_version" in event and "format" in event
-    mapper = Mapper(event['request_id'], event['format'])
+    assert ("request_id" in event and
+            "bundle_uuid" in event and
+            "bundle_version" in event and
+            "filter_string" in event and
+            "format" in event)
+
+    mapper = Mapper(event['request_id'], event['format'], event['filter_string'])
     mapper.run(event['bundle_uuid'], event['bundle_version'])

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -10,23 +10,23 @@ from ...common.lambda_handler import LambdaName
 def post_matrix(body: dict):
     has_ids = 'bundle_fqids' in body
     has_url = 'bundle_fqids_url' in body
-
     format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
+    filter_string = body['filter_string'] if 'filter_string' in body else ""
 
     # Validate input parameters
     if has_ids and has_url:
         return {
             'code': requests.codes.bad_request,
-            'message': "Invalid parameters supplied. "
-                       "Must supply either one of `bundle_fqids` or `bundle_fqids_url`. "
+            'message': "Invalid parameters supplied."
+                       "Must supply either one of `bundle_fqids` or `bundle_fqids_url`."
                        "Visit https://matrix.dev.data.humancellatlas.org for more information."
         }, requests.codes.bad_request
 
     if not has_ids and not has_url:
         return {
             'code': requests.codes.bad_request,
-            'message': "Missing required parameter. "
-                       "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
+            'message': "Missing required parameter."
+                       "One of `bundle_fqids` or `bundle_fqids_url` must be supplied."
                        "Visit https://matrix.dev.data.humancellatlas.org for more information."
         }, requests.codes.bad_request
 
@@ -41,6 +41,7 @@ def post_matrix(body: dict):
     driver_payload = {
         'request_id': request_id,
         'bundle_fqids': bundle_fqids,
+        'filter_string': filter_string,
         'format': format,
     }
     lambda_handler = LambdaHandler()

--- a/matrix/lambdas/daemons/driver.py
+++ b/matrix/lambdas/daemons/driver.py
@@ -13,7 +13,7 @@ class Driver:
         self.lambda_handler = LambdaHandler()
         self.dynamo_handler = DynamoHandler()
 
-    def run(self, request_id: str, bundle_fqids: typing.List[str], format: str):
+    def run(self, request_id: str, bundle_fqids: typing.List[str], filter_string: str, format: str):
         """
         Initialize a filter merge job and spawn a mapper task for each bundle_fqid.
 
@@ -30,6 +30,7 @@ class Driver:
                 'request_id': request_id,
                 'bundle_uuid': bundle_uuid,
                 'bundle_version': bundle_version,
+                'filter_string': filter_string,
                 'format': format,
             }
             self.lambda_handler.invoke(LambdaName.MAPPER, mapper_payload)

--- a/matrix/lambdas/daemons/mapper.py
+++ b/matrix/lambdas/daemons/mapper.py
@@ -16,10 +16,11 @@ class Mapper:
     Mapper takes a single bundle (uuid, version) as input, reads the associated expression matrix
     from the DSS, and invokes a Worker task for each chunk (row subset) of the expression matrix.
     """
-    def __init__(self, request_id: str, format: str):
-        print(f"Mapper initialized with: {request_id}, {format}")
+    def __init__(self, request_id: str, format: str, filter_string: str):
+        print(f"Mapper initialized with: {request_id}, {format}, {filter_string}")
         self.request_id = request_id
         self.format = format
+        self.filter_string = filter_string
 
         self.lambda_handler = LambdaHandler()
         self.dynamo_handler = DynamoHandler()
@@ -60,7 +61,8 @@ class Mapper:
         return {
             'request_id': self.request_id,
             'format': self.format,
-            'worker_chunk_spec': worker_chunk_spec
+            'filter_string': self.filter_string,
+            'worker_chunk_spec': worker_chunk_spec,
         }
 
     @staticmethod

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -16,7 +16,8 @@ class TestCore(unittest.TestCase):
 
         body = {
             'bundle_fqids': bundle_fqids,
-            'format': format
+            'filter_string': "",
+            'format': format,
         }
         response, code = post_matrix(body)
         body.update({'request_id': mock.ANY})

--- a/tests/unit/lambdas/daemons/test_driver.py
+++ b/tests/unit/lambdas/daemons/test_driver.py
@@ -19,7 +19,7 @@ class TestDriver(unittest.TestCase):
         bundle_fqids = ["id1.version", "id2.version"]
         format = "test_format"
 
-        self._driver.run(request_id, bundle_fqids, format)
+        self._driver.run(request_id, bundle_fqids, "", format)
 
         mock_dynamo_create_state_table_entry.assert_called_once_with(request_id, len(bundle_fqids))
         mock_dynamo_create_output_table_entry.assert_called_once_with(request_id)
@@ -27,10 +27,12 @@ class TestDriver(unittest.TestCase):
             call(LambdaName.MAPPER, {'request_id': request_id,
                                      'bundle_uuid': "id1",
                                      'bundle_version': "version",
+                                     'filter_string': "",
                                      'format': format}),
             call(LambdaName.MAPPER, {'request_id': request_id,
                                      'bundle_uuid': "id2",
                                      'bundle_version': "version",
+                                     'filter_string': "",
                                      'format': format}),
         ]
         mock_lambda_invoke.assert_has_calls(expected_calls)

--- a/tests/unit/lambdas/daemons/test_mapper.py
+++ b/tests/unit/lambdas/daemons/test_mapper.py
@@ -14,7 +14,7 @@ class TestMapper(unittest.TestCase):
     def setUp(self):
         self.request_id = str(uuid.uuid4())
         self.format = "test_format"
-        self._mapper = Mapper(self.request_id, self.format)
+        self._mapper = Mapper(self.request_id, self.format, "")
 
     @mock.patch("matrix.lambdas.daemons.mapper.Mapper._get_worker_payload")
     @mock.patch("matrix.lambdas.daemons.mapper.Mapper._get_chunk_specs")
@@ -84,16 +84,12 @@ class TestMapper(unittest.TestCase):
         test_chunk_spec = {}
         expected_payload = {
             'request_id': self.request_id,
+            'filter_string': "",
             'format': self.format,
             'worker_chunk_spec': test_chunk_spec
         }
 
         payload = self._mapper._get_worker_payload(test_chunk_spec)
-
-        self.assertTrue("request_id" in payload)
-        self.assertTrue("format" in payload)
-        self.assertTrue("worker_chunk_spec" in payload)
-
         self.assertEqual(payload, expected_payload)
 
     @mock.patch("zarr.group")


### PR DESCRIPTION
Accept `filter_string` as a body param on `post_matrix` and propagate to Worker nodes