### PR TITLE
Implement basic GET endpoint

### DIFF
--- a/chalice/Makefile
+++ b/chalice/Makefile
@@ -6,7 +6,9 @@ export EXPORT_ENV_VARS_TO_LAMBDA=DEPLOYMENT_STAGE \
                                     LAMBDA_MAPPER_FUNCTION_NAME \
                                     LAMBDA_WORKER_FUNCTION_NAME \
                                     LAMBDA_REDUCER_FUNCTION_NAME \
-                                    DYNAMO_STATE_TABLE_NAME
+                                    DYNAMO_STATE_TABLE_NAME \
+                                    DYNAMO_OUTPUT_TABLE_NAME \
+                                    S3_RESULTS_BUCKET
 
 clean:
 	git clean -df .

--- a/config/environment
+++ b/config/environment
@@ -21,6 +21,7 @@ LAMBDA_WORKER_FUNCTION_NAME="dcp-matrix-service-worker-${DEPLOYMENT_STAGE}"
 LAMBDA_REDUCER_FUNCTION_NAME="dcp-matrix-service-reducer-${DEPLOYMENT_STAGE}"
 DYNAMO_STATE_TABLE_NAME="dcp-matrix-service-state-table-${DEPLOYMENT_STAGE}"
 DYNAMO_OUTPUT_TABLE_NAME="dcp-matrix-service-output-table-${DEPLOYMENT_STAGE}"
+S3_RESULTS_BUCKET="dcp-matrix-service-results-${DEPLOYMENT_STAGE}"
 set +a
 
 echo "DEPLOYMENT STAGE IS \"${DEPLOYMENT_STAGE}\""

--- a/config/iam_policy_templates/matrix-service-api-lambda.json
+++ b/config/iam_policy_templates/matrix-service-api-lambda.json
@@ -15,7 +15,14 @@
       "Action": [
         "lambda:InvokeFunction"
       ],
-      "Resource": "arn:aws:lambda:us-east-1:861229788715:function:dcp-matrix-service-driver-dev"
+      "Resource": "arn:aws:lambda:us-east-1:${account_id}:function:dcp-matrix-service-driver-${DEPLOYMENT_STAGE}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem"
+      ],
+      "Resource": "arn:aws:dynamodb:us-east-1:${account_id}:table/dcp-matrix-service-state-table-${DEPLOYMENT_STAGE}"
     }
   ]
 }

--- a/config/iam_policy_templates/matrix-service-api-lambda.json
+++ b/config/iam_policy_templates/matrix-service-api-lambda.json
@@ -16,17 +16,6 @@
         "lambda:InvokeFunction"
       ],
       "Resource": "arn:aws:lambda:us-east-1:861229788715:function:dcp-matrix-service-driver-dev"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::dcp-matrix-service-results-bucket-dev",
-        "arn:aws:s3:::dcp-matrix-service-results-bucket-dev:*"
-      ]
     }
   ]
 }

--- a/config/iam_policy_templates/matrix-service-api-lambda.json
+++ b/config/iam_policy_templates/matrix-service-api-lambda.json
@@ -16,6 +16,17 @@
         "lambda:InvokeFunction"
       ],
       "Resource": "arn:aws:lambda:us-east-1:861229788715:function:dcp-matrix-service-driver-dev"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::dcp-matrix-service-results-bucket-dev",
+        "arn:aws:s3:::dcp-matrix-service-results-bucket-dev:*"
+      ]
     }
   ]
 }

--- a/config/matrix-api.yml
+++ b/config/matrix-api.yml
@@ -39,16 +39,12 @@ definitions:
         format: uuid
       status:
         $ref: '#/definitions/MatrixRequestStatus'
-      key:
+      matrix_location:
         type: string
       eta:
         type: string
       message:
         type: string
-      links:
-        type: array
-        items:
-          type: object
   MatrixRequestStatus:
     type: string
     enum:
@@ -58,8 +54,6 @@ definitions:
   MatrixResponseError:
     type: object
     properties:
-      code:
-        type: integer
       message:
         type: string
 paths:

--- a/matrix/common/exceptions.py
+++ b/matrix/common/exceptions.py
@@ -1,0 +1,6 @@
+class MatrixException(Exception):
+    def __init__(self, status: int, title: str, detail: str=None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.status = status
+        self.title = title
+        self.detail = detail

--- a/tests/unit/common/test_dynamo_handler.py
+++ b/tests/unit/common/test_dynamo_handler.py
@@ -8,6 +8,7 @@ from matrix.common.dynamo_handler import DynamoHandler
 from matrix.common.dynamo_handler import StateTableField
 from matrix.common.dynamo_handler import OutputTableField
 from matrix.common.dynamo_handler import DynamoTable
+from matrix.common.exceptions import MatrixException
 
 
 class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
@@ -127,3 +128,10 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.handler.increment_table_field(DynamoTable.OUTPUT_TABLE, self.request_id, field_enum, 5)
         entry = self.handler.get_table_item(DynamoTable.OUTPUT_TABLE, self.request_id)
         self.assertEqual(entry[OutputTableField.ROW_COUNT.value], 5)
+
+    def test_get_table_item(self):
+        self.assertRaises(MatrixException, self.handler.get_table_item, DynamoTable.OUTPUT_TABLE, self.request_id)
+
+        self.handler.create_output_table_entry(self.request_id)
+        entry = self.handler.get_table_item(DynamoTable.OUTPUT_TABLE, self.request_id)
+        self.assertEqual(entry[OutputTableField.ROW_COUNT.value], 0)

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -1,11 +1,16 @@
+import os
 import requests
 import unittest
+import uuid
 from unittest import mock
 
 from matrix.common.constants import MatrixFormat
 from matrix.common.constants import MatrixRequestStatus
+from matrix.common.dynamo_handler import StateTableField
+from matrix.common.exceptions import MatrixException
 from matrix.common.lambda_handler import LambdaName
 from matrix.lambdas.api.core import post_matrix
+from matrix.lambdas.api.core import get_matrix
 
 
 class TestCore(unittest.TestCase):
@@ -18,13 +23,13 @@ class TestCore(unittest.TestCase):
             'bundle_fqids': bundle_fqids,
             'format': format
         }
-        response, code = post_matrix(body)
+        response = post_matrix(body)
         body.update({'request_id': mock.ANY})
 
         mock_lambda_invoke.assert_called_once_with(LambdaName.DRIVER, body)
-        self.assertEqual(type(response['request_id']), str)
-        self.assertEqual(response['status'], MatrixRequestStatus.IN_PROGRESS.value)
-        self.assertEqual(code, requests.codes.accepted)
+        self.assertEqual(type(response.body['request_id']), str)
+        self.assertEqual(response.body['status'], MatrixRequestStatus.IN_PROGRESS.value)
+        self.assertEqual(response.status_code, requests.codes.accepted)
 
     @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
     def test_post_matrix_with_ids_and_url(self, mock_lambda_invoke):
@@ -35,14 +40,44 @@ class TestCore(unittest.TestCase):
             'bundle_fqids': bundle_fqids,
             'bundle_fqids_url': bundle_fqids_url
         }
-        response, code = post_matrix(body)
+        response = post_matrix(body)
 
         self.assertEqual(mock_lambda_invoke.call_count, 0)
-        self.assertEqual(code, requests.codes.bad_request)
+        self.assertEqual(response.status_code, requests.codes.bad_request)
 
     @mock.patch("matrix.common.lambda_handler.LambdaHandler.invoke")
     def test_post_matrix_without_ids_or_url(self, mock_lambda_invoke):
-        response, code = post_matrix({})
+        response = post_matrix({})
 
         self.assertEqual(mock_lambda_invoke.call_count, 0)
-        self.assertEqual(code, requests.codes.bad_request)
+        self.assertEqual(response.status_code, requests.codes.bad_request)
+
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.get_table_item")
+    def test_get_matrix_not_found(self, mock_get_table_item):
+        status = 404
+        message = "test_message"
+        request_id = str(uuid.uuid4())
+        mock_get_table_item.side_effect = MatrixException(status, message)
+
+        response = get_matrix(request_id)
+        self.assertEqual(response.status_code, status)
+        self.assertTrue(request_id in response.body['message'])
+
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.get_table_item")
+    def test_get_matrix_processing(self, mock_get_table_item):
+        request_id = str(uuid.uuid4())
+        mock_get_table_item.return_value = {StateTableField.COMPLETED_REDUCER_EXECUTIONS.value: 0}
+
+        response = get_matrix(request_id)
+        self.assertEqual(response.status_code, requests.codes.ok)
+        self.assertEqual(response.body['status'], MatrixRequestStatus.IN_PROGRESS.value)
+
+    @mock.patch("matrix.common.dynamo_handler.DynamoHandler.get_table_item")
+    def test_get_matrix_complete(self, mock_get_table_item):
+        request_id = str(uuid.uuid4())
+        mock_get_table_item.return_value = {StateTableField.COMPLETED_REDUCER_EXECUTIONS.value: 1}
+
+        response = get_matrix(request_id)
+        self.assertEqual(response.status_code, requests.codes.ok)
+        self.assertEqual(response.body['matrix_location'], f"s3://{os.environ['S3_RESULTS_BUCKET']}/{request_id}.zarr")
+        self.assertEqual(response.body['status'], MatrixRequestStatus.COMPLETE.value)


### PR DESCRIPTION
GET endpoint checks DyanmoDB for `CompletedReducerExecutions` to determine if result is ready. If ready, return `200` and the S3 prefix key pointing to where the request results are. If not ready, also return `200`(?) with appropriate messaging.