### PR TITLE
Fix app dependencies

### DIFF
--- a/chalice/Makefile
+++ b/chalice/Makefile
@@ -17,10 +17,14 @@ clobber: clean
 	git checkout .chalice/*.json
 
 build:
-	cp ../requirements.txt .
 	mkdir -p chalicelib/matrix/lambdas
-	cp -R ../matrix/lambdas/api chalicelib/matrix/lambdas/
-	cp -R ../matrix/common chalicelib/matrix/
+	mkdir -p chalicelib/matrix/common
+	cp -R ../matrix/lambdas/api chalicelib/matrix/lambdas
+	cp ../matrix/common/__init__.py chalicelib/matrix/common
+	cp ../matrix/common/constants.py chalicelib/matrix/common
+	cp ../matrix/common/exceptions.py chalicelib/matrix/common
+	cp ../matrix/common/dynamo_handler.py chalicelib/matrix/common
+	cp ../matrix/common/lambda_handler.py chalicelib/matrix/common
 	mkdir -p chalicelib/config
 	envsubst '$$API_HOST' < ../config/matrix-api.yml > chalicelib/config/matrix-api.yml
 	shopt -s nullglob; for wheel in vendor.in/*/*.whl; do unzip -q -o -d vendor $$wheel; done

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -6,7 +6,3 @@ itsdangerous==0.24
 MarkupSafe==1.0
 PyYAML==3.13
 requests==2.19.1
-zarr==2.2.0
-pandas==0.23.4
-hca==4.3.3
-s3fs==0.1.6


### PR DESCRIPTION
Chalice app package was unnecessarily large resulting in timeouts when uploading package to Lambda to deploy API.

Trim Chalice dependencies, add requests