### PR TITLE
Move url parsing logic into driver

### DIFF
--- a/daemons/driver/app.py
+++ b/daemons/driver/app.py
@@ -3,6 +3,8 @@ from matrix.lambdas.daemons.driver import Driver
 
 def driver_handler(event, context):
     # TODO: better error handling
-    assert 'request_id' in event and 'bundle_fqids' in event and 'format' in event
+    assert ('request_id' in event and 'format' in event and "bundle_fqids" in event
+            and "bundle_fqids_url" in event)
+    assert bool(event["bundle_fqids"]) != bool(event["bundle_fqids_url"]) # xor these
     driver = Driver(event['request_id'])
-    driver.run(event['bundle_fqids'], event['format'])
+    driver.run(event['bundle_fqids'], event["bundle_fqids_url"], event['format'])

--- a/daemons/driver/app.py
+++ b/daemons/driver/app.py
@@ -3,8 +3,8 @@ from matrix.lambdas.daemons.driver import Driver
 
 def driver_handler(event, context):
     # TODO: better error handling
-    assert ('request_id' in event and 'format' in event and "bundle_fqids" in event
-            and "bundle_fqids_url" in event)
-    assert bool(event["bundle_fqids"]) != bool(event["bundle_fqids_url"]) # xor these
+    assert ('request_id' in event and 'format' in event and 'bundle_fqids' in event and
+            'bundle_fqids_url' in event)
+    assert bool(event["bundle_fqids"]) != bool(event["bundle_fqids_url"])  # xor these
     driver = Driver(event['request_id'])
     driver.run(event['bundle_fqids'], event["bundle_fqids_url"], event['format'])

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -1,3 +1,4 @@
+import json
 import os
 import requests
 import uuid

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -46,7 +46,7 @@ def post_matrix(body: dict):
                                                 "Visit https://matrix.dev.data.humancellatlas.org for more information."
                                  })
 
-    if not has_url and len(body['bundle_fqids']) > 128000:
+    if not has_url and len(json.dumps(body['bundle_fqids'])) > 128000:
         return ConnexionResponse(status_code=requests.codes.request_entity_too_large,
                                  body={
                                      'message': "List of bundle fqids is too large. "

--- a/matrix/lambdas/daemons/driver.py
+++ b/matrix/lambdas/daemons/driver.py
@@ -2,6 +2,8 @@ import itertools
 import math
 import typing
 
+import requests
+
 from matrix.common.dynamo_handler import DynamoHandler
 from matrix.common.lambda_handler import LambdaHandler, LambdaName
 from matrix.common.logging import Logging
@@ -22,24 +24,32 @@ class Driver:
         self.lambda_handler = LambdaHandler()
         self.dynamo_handler = DynamoHandler()
 
-    def run(self, bundle_fqids: typing.List[str], format: str):
+    def run(self, bundle_fqids: typing.List[str], bundle_fqids_url: str, format: str):
         """
         Initialize a filter merge job and spawn a mapper task for each bundle_fqid.
 
         :param bundle_fqids: List of bundle fqids to be queried on
+        :param bundle_fqids_url: URL from which bundle_fqids can be retrieved
         :param format: MatrixFormat file format of output expression matrix
         """
         logger.debug(f"Driver running with parameters: bundle_fqids={bundle_fqids}, "
-                     f"format={format}, bundles_per_worker={self.bundles_per_worker}")
+                     f"bundle_fqids_url={bundle_fqids_url}, format={format}, "
+                     f"bundles_per_worker={self.bundles_per_worker}")
 
-        num_expected_mappers = int(math.ceil(len(bundle_fqids) / self.bundles_per_worker))
+        if bundle_fqids_url:
+            data = requests.get(bundle_fqids_url)
+            resolved_bundle_fqids = self._parse_download_manifest(data)
+        else:
+            resolved_bundle_fqids = bundle_fqids
+
+        num_expected_mappers = int(math.ceil(len(resolved_bundle_fqids) / self.bundles_per_worker))
         self.dynamo_handler.create_state_table_entry(self.request_id, num_expected_mappers, format)
         self.dynamo_handler.create_output_table_entry(self.request_id, format)
 
         logger.debug(f"Invoking {num_expected_mappers} Mapper(s) with approximately "
                      f"{self.bundles_per_worker} bundles per Mapper.")
 
-        for bundle_fqid_group in self._group_bundles(bundle_fqids, self.bundles_per_worker):
+        for bundle_fqid_group in self._group_bundles(resolved_bundle_fqids, self.bundles_per_worker):
             mapper_payload = {
                 'request_id': self.request_id,
                 'bundle_fqids': bundle_fqid_group,
@@ -54,3 +64,12 @@ class Driver:
         iter_args = [iter(bundle_fqids)] * bundles_per_group
         for bundle_fqid_group in itertools.zip_longest(*iter_args):
             yield list(filter(None, bundle_fqid_group))
+
+    @staticmethod
+    def _parse_download_manifest(data: str) -> typing.List[str]:
+        def _parse_line(line: str) -> str:
+            tokens = line.split("\t")
+            return f"{tokens[0]}.{tokens[1]}"
+
+        lines = data.splitlines()[1:]
+        return list(map(_parse_line, lines))

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -25,6 +25,7 @@ class TestCore(unittest.TestCase):
         }
         response = post_matrix(body)
         body.update({'request_id': mock.ANY})
+        body.update({'bundle_fqids_url': None})
 
         mock_lambda_invoke.assert_called_once_with(LambdaName.DRIVER, body)
         self.assertEqual(type(response.body['request_id']), str)

--- a/tests/unit/lambdas/daemons/test_driver.py
+++ b/tests/unit/lambdas/daemons/test_driver.py
@@ -21,7 +21,7 @@ class TestDriver(unittest.TestCase):
         bundle_fqids = ["id1.version", "id2.version"]
         format = "test_format"
 
-        self._driver.run(bundle_fqids, format)
+        self._driver.run(bundle_fqids, None, format)
 
         num_mappers = math.ceil(len(bundle_fqids) / self._bundles_per_worker)
         mock_dynamo_create_state_table_entry.assert_called_once_with(self.request_id, num_mappers, format)


### PR DESCRIPTION
There's a limit on request size for a lambda, so we can't pass the whole
list of bundle fqids to the driver.

For the mappers and workers, this is less of a concern because we split
up the list of fqids into pretty small chunks.