### PR TITLE
change resource path for batch

### DIFF
--- a/terraform/modules/matrix-service/lambdas/reducer_lambda.tf
+++ b/terraform/modules/matrix-service/lambdas/reducer_lambda.tf
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy" "matrix_service_reducer_lambda" {
         "batch:SubmitJob"
       ],
       "Resource": [
-        "arn:aws:batch:*:${var.account_id}:*"
+        "*"
       ]
     }
   ]


### PR DESCRIPTION
Batch does not support resource paths. All batch permissions need resource path of *

Message in iam console: The actions in your policy do not support resource-level permissions and require you to choose All resources