### PR TITLE
Convert DSS unit tests to functional tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,29 @@
+test_bundle_spec = {
+    "uuid": "ba9c63ac-6db5-48bc-a2e3-7be4ddd03d97",
+    "version": "2018-10-17T173508.111787Z",
+    "replica": "aws",
+    "description": {
+        "shapes": {
+            "cell_id": (1,),
+            "cell_metadata_numeric": (1, 151),
+            "cell_metadata_numeric_name": (151,),
+            "cell_metadata_string": (1, 3),
+            "cell_metadata_string_name": (3,),
+            "expression": (1, 58347),
+            "gene_id": (58347,)
+        },
+        "sums": {
+            "expression": 1000000,
+            "cell_metadata_numeric": 5859988
+        },
+        "digests": {
+            "cell_id": b'fefa87f9820656e61298827f94fc537c198b8b23',
+            "cell_metadata_numeric": b'49181b9040b3cfa386cb2282c00a25eddbf480d5',
+            "cell_metadata_numeric_name": b'f4e8156b933c1295afd5468c398991cd9712ba26',
+            "cell_metadata_string": b'ef70f6bde79d7f61cf6eb89e16b29bec912565fb',
+            "cell_metadata_string_name": b'bdd2ea7e0b4424872681f778c78cc8f0ee66cfa2',
+            "expression": b'b8b66e56cdff65c719eea8b9313e990ec01237b3',
+            "gene_id": b'c251ac69ceda370d512f37873715114c25fdfb39'
+        }
+    }
+}

--- a/tests/functional/test_dss.py
+++ b/tests/functional/test_dss.py
@@ -1,0 +1,32 @@
+import binascii
+import unittest
+
+import numpy
+import pytest
+import zarr
+
+from matrix.common.zarr.dss_zarr_store import DSSZarrStore
+from tests import test_bundle_spec
+
+
+class TestDss(unittest.TestCase):
+
+    def test_dss_store_read(self):
+        """Test using the DSSZarrStore with zarr."""
+
+        bundle_uuid = test_bundle_spec["uuid"]
+        bundle_version = test_bundle_spec["version"]
+        replica = test_bundle_spec["replica"]
+        expected_values = test_bundle_spec["description"]
+
+        hca_store = DSSZarrStore(bundle_uuid=bundle_uuid, bundle_version=bundle_version, replica=replica)
+        matrix_root = zarr.group(store=hca_store)
+
+        for dset, expected_shape in expected_values.get("shapes", {}).items():
+            assert getattr(matrix_root, dset).shape == expected_shape
+
+        for dset, expected_sum in expected_values.get("sums", {}).items():
+            assert numpy.sum(getattr(matrix_root, dset)) == pytest.approx(expected_sum, 1)
+
+        for dset, expected_digest in expected_values.get("digests", {}).items():
+            assert binascii.hexlify(getattr(matrix_root, dset).digest()) == expected_digest

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -17,36 +17,6 @@ os.environ['DYNAMO_CACHE_TABLE_NAME'] = f"dcp-matrix-service-cache-table-{os.env
 os.environ['S3_RESULTS_BUCKET'] = f"dcp-matrix-service-results-{os.environ['DEPLOYMENT_STAGE']}"
 os.environ['DYNAMO_LOCK_TABLE_NAME'] = f"dcp-matrix-service-lock-table-{os.environ['DEPLOYMENT_STAGE']}"
 
-test_bundle_spec = {
-    "uuid": "ba9c63ac-6db5-48bc-a2e3-7be4ddd03d97",
-    "version": "2018-10-17T173508.111787Z",
-    "replica": "aws",
-    "description": {
-        "shapes": {
-            "cell_id": (1,),
-            "cell_metadata_numeric": (1, 151),
-            "cell_metadata_numeric_name": (151,),
-            "cell_metadata_string": (1, 3),
-            "cell_metadata_string_name": (3,),
-            "expression": (1, 58347),
-            "gene_id": (58347,)
-        },
-        "sums": {
-            "expression": 1000000,
-            "cell_metadata_numeric": 5859988
-        },
-        "digests": {
-            "cell_id": b'fefa87f9820656e61298827f94fc537c198b8b23',
-            "cell_metadata_numeric": b'49181b9040b3cfa386cb2282c00a25eddbf480d5',
-            "cell_metadata_numeric_name": b'f4e8156b933c1295afd5468c398991cd9712ba26',
-            "cell_metadata_string": b'ef70f6bde79d7f61cf6eb89e16b29bec912565fb',
-            "cell_metadata_string_name": b'bdd2ea7e0b4424872681f778c78cc8f0ee66cfa2',
-            "expression": b'b8b66e56cdff65c719eea8b9313e990ec01237b3',
-            "gene_id": b'c251ac69ceda370d512f37873715114c25fdfb39'
-        }
-    }
-}
-
 
 class MatrixTestCaseUsingMockAWS(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/common/aws/test_dss_zarr_store.py
+++ b/tests/unit/common/aws/test_dss_zarr_store.py
@@ -1,13 +1,7 @@
-import binascii
 import os
 import unittest
 
-import numpy
-import pytest
-import zarr
-
 from matrix.common.zarr.dss_zarr_store import DSSZarrStore
-from tests.unit import test_bundle_spec
 
 
 class TestDSSZarrStore(unittest.TestCase):
@@ -25,23 +19,3 @@ class TestDSSZarrStore(unittest.TestCase):
             os.environ['DEPLOYMENT_STAGE'] = env
             client = DSSZarrStore.get_dss_client()
             self.assertTrue(env_to_dss_host[env], client.host)
-
-    def _test_hca_store_read(self):
-        """Test using the DSSZarrStore with zarr."""
-
-        bundle_uuid = test_bundle_spec["uuid"]
-        bundle_version = test_bundle_spec["version"]
-        replica = test_bundle_spec["replica"]
-        expected_values = test_bundle_spec["description"]
-
-        hca_store = DSSZarrStore(bundle_uuid=bundle_uuid, bundle_version=bundle_version, replica=replica)
-        matrix_root = zarr.group(store=hca_store)
-
-        for dset, expected_shape in expected_values.get("shapes", {}).items():
-            assert getattr(matrix_root, dset).shape == expected_shape
-
-        for dset, expected_sum in expected_values.get("sums", {}).items():
-            assert numpy.sum(getattr(matrix_root, dset)) == pytest.approx(expected_sum, 1)
-
-        for dset, expected_digest in expected_values.get("digests", {}).items():
-            assert binascii.hexlify(getattr(matrix_root, dset).digest()) == expected_digest

--- a/tests/unit/common/zarr/test_pandas_utils.py
+++ b/tests/unit/common/zarr/test_pandas_utils.py
@@ -7,7 +7,7 @@ import zarr
 from matrix.common.zarr.pandas_utils import convert_dss_zarr_root_to_subset_pandas_dfs
 from matrix.common.zarr.pandas_utils import apply_filter_to_matrix_pandas_dfs
 from matrix.common.zarr.dss_zarr_store import DSSZarrStore
-from tests.unit import test_bundle_spec
+from tests import test_bundle_spec
 
 
 class TestPandasUtils(unittest.TestCase):

--- a/tests/unit/lambdas/daemons/test_worker.py
+++ b/tests/unit/lambdas/daemons/test_worker.py
@@ -4,11 +4,11 @@ import os
 from pandas import DataFrame
 from unittest import mock
 
-from ... import MatrixTestCaseUsingMockAWS
-from ... import test_bundle_spec
 from matrix.lambdas.daemons.worker import Worker
 from matrix.common.aws.lambda_handler import LambdaName
 from matrix.common.request.request_tracker import Subtask
+from tests import test_bundle_spec
+from tests.unit import MatrixTestCaseUsingMockAWS
 
 
 class TestWorker(MatrixTestCaseUsingMockAWS):


### PR DESCRIPTION
This unit test was disabled due to long running times contacting the DSS. These changes move it to functional tests.

- unit tests passing
- functional tests passing on predev