### PR TITLE
Handle new numcodecs decode output

### DIFF
--- a/matrix/common/zarr/s3_zarr_store.py
+++ b/matrix/common/zarr/s3_zarr_store.py
@@ -115,7 +115,7 @@ class S3ZarrStore:
                     try:
                         arr = numpy.frombuffer(
                             ZARR_OUTPUT_CONFIG['compressor'].decode(
-                                self.s3_file_system.open(full_dest_key, 'rb').read()),
+                                self.s3_file_system.open(full_dest_key, 'rb').read()).base,
                             dtype=dtype).reshape(chunk_shape, order=ZARR_OUTPUT_CONFIG['order'])
                         break
                     except FileNotFoundError:


### PR DESCRIPTION
Numcodecs decode used to return a buffer, but as of 0.6.0, it returns an array.