### PR TITLE
Add ignore_cache option to POST /matrix

### DIFF
--- a/config/matrix-api.yml
+++ b/config/matrix-api.yml
@@ -25,6 +25,8 @@ definitions:
         format: url
       format:
         $ref: '#/definitions/MatrixFormat'
+      ignore_cache:
+        type: boolean
   MatrixFormat:
     type: string
     enum:

--- a/daemons/driver/app.py
+++ b/daemons/driver/app.py
@@ -4,7 +4,7 @@ from matrix.lambdas.daemons.driver import Driver
 def driver_handler(event, context):
     # TODO: better error handling
     assert ('request_id' in event and 'format' in event and 'bundle_fqids' in event and
-            'bundle_fqids_url' in event)
+            'bundle_fqids_url' in event and 'ignore_cache')
     assert bool(event["bundle_fqids"]) != bool(event["bundle_fqids_url"])  # xor these
     driver = Driver(event['request_id'])
-    driver.run(event['bundle_fqids'], event["bundle_fqids_url"], event['format'])
+    driver.run(event['bundle_fqids'], event["bundle_fqids_url"], event['format'], event['ignore_cache'])

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -17,6 +17,7 @@ def post_matrix(body: dict):
 
     format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
     expected_formats = [mf.value for mf in MatrixFormat]
+    api_host = os.environ['API_HOST']
 
     # Validate input parameters
     if format not in expected_formats:
@@ -24,14 +25,14 @@ def post_matrix(body: dict):
                                  body={
                                      'message': "Invalid parameters supplied. "
                                                 "Please supply a valid `format`. "
-                                                "Visit https://matrix.dev.data.humancellatlas.org for more information."
+                                                f"Visit {api_host} for more information."
                                  })
     if has_ids and has_url:
         return ConnexionResponse(status_code=requests.codes.bad_request,
                                  body={
                                      'message': "Invalid parameters supplied. "
                                                 "Please supply either one of `bundle_fqids` or `bundle_fqids_url`. "
-                                                "Visit https://matrix.dev.data.humancellatlas.org for more information."
+                                                f"Visit {api_host} for more information."
                                  })
 
     if not has_ids and not has_url:
@@ -39,7 +40,7 @@ def post_matrix(body: dict):
                                  body={
                                      'message': "Missing required parameter. "
                                                 "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
-                                                "Visit https://matrix.dev.data.humancellatlas.org for more information."
+                                                f"Visit {api_host} for more information."
                                  })
 
     if not has_url and len(json.dumps(body['bundle_fqids'])) > 128000:
@@ -47,7 +48,7 @@ def post_matrix(body: dict):
                                  body={
                                      'message': "List of bundle fqids is too large. "
                                                 "Consider using bundle_fqids_url instead. "
-                                                "Visit https://matrix.dev.data.humancellatlas.org for more information."
+                                                f"Visit {api_host} for more information."
                                  })
 
     if has_url:

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -16,6 +16,7 @@ def post_matrix(body: dict):
     has_url = 'bundle_fqids_url' in body
 
     format = body['format'] if 'format' in body else MatrixFormat.ZARR.value
+    ignore_cache = body['ignore_cache'] if 'ignore_cache' in body else False
     expected_formats = [mf.value for mf in MatrixFormat]
     api_host = os.environ['API_HOST']
 
@@ -66,6 +67,7 @@ def post_matrix(body: dict):
         'bundle_fqids': bundle_fqids,
         'bundle_fqids_url': bundle_fqids_url,
         'format': format,
+        'ignore_cache': ignore_cache,
     }
     lambda_handler = LambdaHandler()
     lambda_handler.invoke(LambdaName.DRIVER, driver_payload)

--- a/matrix/lambdas/daemons/driver.py
+++ b/matrix/lambdas/daemons/driver.py
@@ -24,16 +24,17 @@ class Driver:
 
         self.lambda_handler = LambdaHandler()
 
-    def run(self, bundle_fqids: typing.List[str], bundle_fqids_url: str, format: str):
+    def run(self, bundle_fqids: typing.List[str], bundle_fqids_url: str, format: str, ignore_cache: bool):
         """
         Initialize a filter merge job and spawn a mapper task for each bundle_fqid.
 
         :param bundle_fqids: List of bundle fqids to be queried on
         :param bundle_fqids_url: URL from which bundle_fqids can be retrieved
         :param format: MatrixFormat file format of output expression matrix
+        :param ignore_cache: Skips request cache if True, else checks cache for existing request
         """
         logger.debug(f"Driver running with parameters: bundle_fqids={bundle_fqids}, "
-                     f"bundle_fqids_url={bundle_fqids_url}, format={format}, "
+                     f"bundle_fqids_url={bundle_fqids_url}, format={format}, ignore_cache={ignore_cache}"
                      f"bundles_per_worker={self.bundles_per_worker}")
 
         if bundle_fqids_url:
@@ -43,7 +44,9 @@ class Driver:
             resolved_bundle_fqids = bundle_fqids
         logger.debug(f"resolved bundles: {resolved_bundle_fqids}")
 
-        request_hash = RequestCache(self.request_id).set_hash(resolved_bundle_fqids, format)
+        request_hash = RequestCache(self.request_id).set_hash(resolved_bundle_fqids,
+                                                              format,
+                                                              deterministic=not ignore_cache)
         logger.debug(f"Calculated and set hash {request_hash} for request {self.request_id}")
         request_tracker = RequestTracker(request_hash)
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -5,6 +5,7 @@ import boto3
 
 from moto import mock_dynamodb2, mock_s3
 
+os.environ['API_HOST'] = "test_api_host"
 os.environ['DEPLOYMENT_STAGE'] = "test_deployment_stage"
 os.environ['AWS_DEFAULT_REGION'] = "us-east-1"
 os.environ['AWS_ACCESS_KEY_ID'] = "test_ak"

--- a/tests/unit/common/request/test_request_cache.py
+++ b/tests/unit/common/request/test_request_cache.py
@@ -35,12 +35,21 @@ class TestRequestCache(MatrixTestCaseUsingMockAWS):
         hash_2 = RequestCache(str(uuid.uuid4())).set_hash(copy_bundle_fqids, format_)
         hash_3 = RequestCache(str(uuid.uuid4())).set_hash(bundle_fqids, format_ + '_')
 
-        self.assertEqual(hash_1, hash_2)
-        self.assertNotEqual(hash_2, hash_3)
+        with self.subTest("Deterministic hash algorithm"):
+            self.assertEqual(hash_1, hash_2)
+            self.assertNotEqual(hash_2, hash_3)
 
-        retrieved_hash = self.request_cache.retrieve_hash()
-        self.assertEqual(retrieved_hash, hash_1)
+            retrieved_hash = self.request_cache.retrieve_hash()
+            self.assertEqual(retrieved_hash, hash_1)
+
+        with self.subTest("Non-deterministic hash algorithm"):
+            hash_4 = RequestCache(str(uuid.uuid4())).set_hash(copy_bundle_fqids, format_, False)
+            self.assertNotEqual(hash_2, hash_4)
 
     def test_initialize(self):
         self.request_cache.initialize()
         self.assertIsNone(self.request_cache.retrieve_hash())
+
+    def test_generate_salt(self):
+        salt = RequestCache._generate_salt(10)
+        self.assertEqual(len(salt), 10)

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -25,8 +25,11 @@ class TestCore(unittest.TestCase):
         }
 
         response = post_matrix(body)
-        body.update({'request_id': mock.ANY})
-        body.update({'bundle_fqids_url': None})
+        body.update({
+            'request_id': mock.ANY,
+            'bundle_fqids_url': None,
+            'ignore_cache': False
+        })
 
         mock_lambda_invoke.assert_called_once_with(LambdaName.DRIVER, body)
         mock_write_request_hash.assert_called_once_with(mock.ANY, "null")
@@ -46,8 +49,11 @@ class TestCore(unittest.TestCase):
         }
 
         response = post_matrix(body)
-        body.update({'request_id': mock.ANY})
-        body.update({'bundle_fqids': None})
+        body.update({
+            'request_id': mock.ANY,
+            'bundle_fqids': None,
+            'ignore_cache': False
+        })
 
         mock_lambda_invoke.assert_called_once_with(LambdaName.DRIVER, body)
         mock_write_request_hash.assert_called_once_with(mock.ANY, "null")

--- a/tests/unit/lambdas/daemons/test_driver.py
+++ b/tests/unit/lambdas/daemons/test_driver.py
@@ -31,7 +31,7 @@ class TestDriver(unittest.TestCase):
         format = "test_format"
 
         mock_is_initialized.return_value = False
-        self._driver.run(bundle_fqids, None, format)
+        self._driver.run(bundle_fqids, None, format, False)
 
         mock_is_initialized.assert_called_once()
         mock_write_request_hash.assert_called_once()
@@ -69,7 +69,7 @@ class TestDriver(unittest.TestCase):
 
         mock_parse_download_manifest.return_value = bundle_fqids
         mock_is_initialized.return_value = False
-        self._driver.run(None, bundle_fqids_url, format)
+        self._driver.run(None, bundle_fqids_url, format, False)
 
         mock_parse_download_manifest.assert_called_once()
         mock_is_initialized.assert_called_once()
@@ -106,7 +106,7 @@ class TestDriver(unittest.TestCase):
 
         mock_is_initialized.return_value = True
         mock_error.return_value = 0
-        self._driver.run(bundle_fqids, None, format)
+        self._driver.run(bundle_fqids, None, format, False)
 
         mock_is_initialized.assert_called_once()
         mock_error.assert_called_once()


### PR DESCRIPTION
**Changes**
These changes add the input parameter `ignore_cache` to the POST /matrix endpoint. The parameter determines the following behavior in the Driver:
- if `True`, `RequestHash._hash_request` will non-deterministically compute a request hash to avoid a cache hit
- if `False`, `RequestHash._hash_request` will compute the request hash normally (deterministically)

**Design**
Currently, there is a need to test the service independent of its caching mechanism in order to test all of its components and gather comprehensive performance metrics. Furthermore, not all errors are captured during processing which may result in a "hanging" request stuck in the "In Progress" state. The `ignore_cache` flag solves these issues by providing a bypass to the caching mechanism to:

1) Run tests independent of the caching mechanism
2) Rerun "stuck" or corrupt requests

An alternative solution to resolve (1) could be to delete requests issued by tests which is the current implementation. This is a sufficient solution, however, the added benefit of (2) I believe justifies the value of the flag.
