### PR TITLE
upgrade PyYAML to 4.2b1

### DIFF
--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -4,5 +4,5 @@ connexion==1.5.2
 inflection==0.3.1
 itsdangerous==0.24
 MarkupSafe==1.0
-PyYAML==3.13
+PyYAML==4.2b1
 requests==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ connexion==1.5.2
 inflection==0.3.1
 itsdangerous==0.24
 MarkupSafe==1.0
-PyYAML==3.13
+PyYAML==4.2b1
 requests==2.20.0
 zarr==2.2.0
 pandas==0.23.4


### PR DESCRIPTION
Addressing https://github.com/HumanCellAtlas/matrix-service/network/alert/chalice/requirements.txt/pyyaml/open

Pre-release version 4.2b1 is 6 months old: https://pypi.org/project/PyYAML/#history
What are the risks of upgrading to it?