### PR TITLE
Fix broken cache, implement timeouts

### DIFF
--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -123,8 +123,18 @@ def get_matrix(request_id: str):
 
     format = request_tracker.format
 
+    # Failed case
+    if request_tracker.error:
+        return ConnexionResponse(status_code=requests.codes.ok,
+                                 body={
+                                     'request_id': request_id,
+                                     'status': MatrixRequestStatus.FAILED.value,
+                                     'matrix_location': "",
+                                     'eta': "",
+                                     'message': request_tracker.error,
+                                 })
     # Complete case
-    if request_tracker.is_request_complete():
+    elif request_tracker.is_request_complete():
         s3_results_bucket = os.environ['S3_RESULTS_BUCKET']
 
         matrix_location = ""
@@ -145,17 +155,6 @@ def get_matrix(request_id: str):
                                                 f"The resultant expression matrix is available for download at "
                                                 f"{matrix_location}",
                                  })
-    # Failed case
-    elif request_tracker.error:
-        return ConnexionResponse(status_code=requests.codes.ok,
-                                 body={
-                                     'request_id': request_id,
-                                     'status': MatrixRequestStatus.FAILED.value,
-                                     'matrix_location': "",
-                                     'eta': "",
-                                     'message': request_tracker.error,
-                                 })
-
     # In progress case
     return ConnexionResponse(status_code=requests.codes.ok,
                              body={

--- a/terraform/modules/matrix-service/infra/s3.tf
+++ b/terraform/modules/matrix-service/infra/s3.tf
@@ -1,17 +1,6 @@
 resource "aws_s3_bucket" "matrix-results" {
   bucket = "dcp-matrix-service-results-${var.deployment_stage}"
   acl    = "public-read"
-
-  lifecycle_rule {
-    id      = "matrix_service_results_expiration"
-
-    expiration {
-      days = 28
-    }
-
-    enabled = true
-  }
-  # Add tags later
 }
 
 resource "aws_s3_bucket_policy" "matrix_results_bucket_policy" {


### PR DESCRIPTION
**Cache Invalidation**
With these changes, a request in the cache can be invalidated by writing an Error value to the Output table. Doing so will result in:
- Failed returned on GET(request_id) and [fix NoSuchKey error](https://github.com/HumanCellAtlas/matrix-service/issues/181)
- Request can be re-run by resubmitting the POST request (currently forever stuck In Progress)

**Other cache fixes:**
- removed expiration bucket policy on S3 results bucket (source of NoSuchKey error)
- requests older than 1 hour will return Failed on GET instead of In Progress