### PR TITLE
add Redshift security group to terraform

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -39,4 +39,5 @@ module "matrix_service_redshift" {
   deployment_stage = "${var.deployment_stage}"
   redshift_username = "${var.redshift_username}"
   redshift_password = "${var.redshift_password}"
+  default_vpc_id = "${var.default_vpc_id}"
 }

--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -39,5 +39,6 @@ module "matrix_service_redshift" {
   deployment_stage = "${var.deployment_stage}"
   redshift_username = "${var.redshift_username}"
   redshift_password = "${var.redshift_password}"
-  default_vpc_id = "${var.default_vpc_id}"
+  vpc_id = "${module.matrix_service_infra.vpc_id}"
+  vpc_subnet_ids = "${module.matrix_service_infra.vpc_subnet_ids}"
 }

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -25,7 +25,3 @@ variable "redshift_username" {
 variable "redshift_password" {
   type = "string"
 }
-
-variable "default_vpc_id" {
-  type = "string"
-}

--- a/terraform/envs/dev/variables.tf
+++ b/terraform/envs/dev/variables.tf
@@ -25,3 +25,7 @@ variable "redshift_username" {
 variable "redshift_password" {
   type = "string"
 }
+
+variable "default_vpc_id" {
+  type = "string"
+}

--- a/terraform/modules/matrix-service/infra/vpc.tf
+++ b/terraform/modules/matrix-service/infra/vpc.tf
@@ -135,3 +135,11 @@ resource "aws_default_security_group" "sg" {
 data "aws_subnet_ids" "matrix_vpc" {
   vpc_id = "${aws_vpc.vpc.id}"
 }
+
+output "vpc_id" {
+  value = "${aws_vpc.vpc.id}"
+}
+
+output "vpc_subnet_ids" {
+  value = "${data.aws_subnet_ids.matrix_vpc.ids}"
+}

--- a/terraform/modules/matrix-service/redshift/redshift.tf
+++ b/terraform/modules/matrix-service/redshift/redshift.tf
@@ -7,12 +7,18 @@ resource "aws_redshift_cluster" "default" {
   cluster_type       = "multi-node"
   number_of_nodes    = 4
   iam_roles          = ["${aws_iam_role.matrix_service_redshift.arn}"]
-  vpc_security_group_ids = ["${aws_security_group.matrix_service_redshift.id}"]
+  cluster_subnet_group_name = "${aws_redshift_subnet_group.matrix_service_redshift.name}"
+  vpc_security_group_ids = ["${aws_security_group.matrix_service_redshift_sg.id}"]
 }
 
-resource "aws_security_group" "matrix_service_redshift" {
-  vpc_id = "${var.default_vpc_id}"
-  name = "matrix-service-redshift-sg-${var.deployment_stage}"
+resource "aws_redshift_subnet_group" "matrix_service_redshift" {
+  name = "matrix-service-redshift-subnet-${var.deployment_stage}"
+  subnet_ids = ["${var.vpc_subnet_ids}"]
+}
+
+resource "aws_security_group" "matrix_service_redshift_sg" {
+  vpc_id = "${var.vpc_id}"
+  name = "matrix-service-rs-sg-${var.deployment_stage}"
 
   ingress {
     protocol = "tcp"
@@ -28,7 +34,6 @@ resource "aws_security_group" "matrix_service_redshift" {
     to_port = 5439
     cidr_blocks = ["0.0.0.0/0"]
   }
-
 }
 
 resource "aws_iam_role" "matrix_service_redshift" {

--- a/terraform/modules/matrix-service/redshift/redshift.tf
+++ b/terraform/modules/matrix-service/redshift/redshift.tf
@@ -7,6 +7,28 @@ resource "aws_redshift_cluster" "default" {
   cluster_type       = "multi-node"
   number_of_nodes    = 4
   iam_roles          = ["${aws_iam_role.matrix_service_redshift.arn}"]
+  vpc_security_group_ids = ["${aws_security_group.matrix_service_redshift.id}"]
+}
+
+resource "aws_security_group" "matrix_service_redshift" {
+  vpc_id = "${var.default_vpc_id}"
+  name = "matrix-service-redshift-sg-${var.deployment_stage}"
+
+  ingress {
+    protocol = "tcp"
+    self = true
+    from_port = 5439
+    to_port = 5439
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol = "tcp"
+    from_port = 5439
+    to_port = 5439
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
 }
 
 resource "aws_iam_role" "matrix_service_redshift" {

--- a/terraform/modules/matrix-service/redshift/variables.tf
+++ b/terraform/modules/matrix-service/redshift/variables.tf
@@ -9,3 +9,7 @@ variable "redshift_username" {
 variable "redshift_password" {
   type = "string"
 }
+
+variable "default_vpc_id" {
+  type = "string"
+}

--- a/terraform/modules/matrix-service/redshift/variables.tf
+++ b/terraform/modules/matrix-service/redshift/variables.tf
@@ -10,6 +10,10 @@ variable "redshift_password" {
   type = "string"
 }
 
-variable "default_vpc_id" {
+variable "vpc_id" {
   type = "string"
+}
+
+variable "vpc_subnet_ids" {
+  type = "list"
 }


### PR DESCRIPTION
- ~Security group is in the `hca` account's default VPC as it is currently publicly accessible~
- moved cluster into Matrix VPC per @parthshahva's comment
