### PR TITLE
put sqs between api and notification lambda

### DIFF
--- a/config/iam_policy_templates/matrix-service-api-lambda.json
+++ b/config/iam_policy_templates/matrix-service-api-lambda.json
@@ -23,8 +23,7 @@
         "lambda:InvokeFunction"
       ],
       "Resource": [
-        "arn:aws:lambda:us-east-1:${account_id}:function:dcp-matrix-service-driver-${DEPLOYMENT_STAGE}",
-        "arn:aws:lambda:us-east-1:${account_id}:function:dcp-matrix-service-notification-${DEPLOYMENT_STAGE}"
+        "arn:aws:lambda:us-east-1:${account_id}:function:dcp-matrix-service-driver-${DEPLOYMENT_STAGE}"
       ]
     },
     {
@@ -44,6 +43,25 @@
       ],
       "Resource": [
         "arn:aws:dynamodb:us-east-1:${account_id}:table/dcp-matrix-service-state-table-${DEPLOYMENT_STAGE}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:SendMessage"
+      ],
+      "Resource": [
+        "arn:aws:sqs:us-east-1:${account_id}:dcp-matrix-notification-queue-${DEPLOYMENT_STAGE}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:us-east-1:${account_id}:secret:dcp/matrix/${DEPLOYMENT_STAGE}/*"
       ]
     }
   ]

--- a/matrix/lambdas/api/core.py
+++ b/matrix/lambdas/api/core.py
@@ -7,10 +7,14 @@ from connexion.lifecycle import ConnexionResponse
 
 from matrix.common.exceptions import MatrixException
 from matrix.common.constants import MatrixFormat, MatrixRequestStatus
+from matrix.common.config import MatrixInfraConfig
 from matrix.common.aws.lambda_handler import LambdaHandler, LambdaName
 from matrix.common.request.request_tracker import RequestTracker
+from matrix.common.aws.sqs_handler import SQSHandler
 
 lambda_handler = LambdaHandler()
+sqs_handler = SQSHandler()
+matrix_infra_config = MatrixInfraConfig()
 
 
 def post_matrix(body: dict):
@@ -167,7 +171,8 @@ def dss_notification(body):
         'bundle_version': bundle_version,
         'event_type': event_type,
     }
-    lambda_handler.invoke(LambdaName.NOTIFICATION, payload)
+    queue_url = matrix_infra_config.notification_q_url
+    sqs_handler.add_message_to_queue(queue_url, payload)
 
     return ConnexionResponse(status_code=requests.codes.ok,
                              body=f"Received notification from subscription {subscription_id}: "

--- a/terraform/modules/matrix-service/infra/secrets.tf
+++ b/terraform/modules/matrix-service/infra/secrets.tf
@@ -7,7 +7,8 @@ resource "aws_secretsmanager_secret_version" "infra_secrets" {
   secret_string = <<SECRETS_JSON
 {
   "query_job_q_url": "${aws_sqs_queue.query_queue.id}",
-  "query_job_deadletter_q_url": "${aws_sqs_queue.query_deadletter_queue.id}"
+  "query_job_deadletter_q_url": "${aws_sqs_queue.query_deadletter_queue.id}",
+  "notification_q_url": "${aws_sqs_queue.notification_queue.id}"
 }
 SECRETS_JSON
 }

--- a/terraform/modules/matrix-service/infra/sqs.tf
+++ b/terraform/modules/matrix-service/infra/sqs.tf
@@ -11,3 +11,24 @@ resource "aws_sqs_queue" "query_deadletter_queue" {
   name                      = "dcp-matrix-query-deadletter-queue-${var.deployment_stage}"
   message_retention_seconds = 1209600
 }
+
+resource "aws_sqs_queue" "notification_queue" {
+  name                      = "dcp-matrix-notification-queue-${var.deployment_stage}"
+//  Queue visibility timeout must be larger than (triggered lambda) function timeout
+  visibility_timeout_seconds = 1800
+  message_retention_seconds = 86400
+  redrive_policy            = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.notification_deadletter_queue.arn}\",\"maxReceiveCount\":4}"
+
+}
+
+resource "aws_sqs_queue" "notification_deadletter_queue" {
+  name                      = "dcp-matrix-notification-deadletter-queue-${var.deployment_stage}"
+  message_retention_seconds = 1209600
+}
+
+resource "aws_lambda_event_source_mapping" "notification_source_mapping" {
+  batch_size = 1
+  event_source_arn  = "${aws_sqs_queue.notification_queue.arn}"
+  enabled           = true
+  function_name     = "arn:aws:lambda:${var.aws_region}:${var.account_id}:function:dcp-matrix-service-notification-${var.deployment_stage}"
+}

--- a/terraform/modules/matrix-service/lambdas/notification_lambda.tf
+++ b/terraform/modules/matrix-service/lambdas/notification_lambda.tf
@@ -72,6 +72,19 @@ resource "aws_iam_role_policy" "matrix_service_notification_lambda" {
       "Resource": [
         "arn:aws:secretsmanager:${var.aws_region}:${var.account_id}:secret:dcp/matrix/${var.deployment_stage}/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:ChangeMessageVisibility",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage"
+      ],
+      "Resource": [
+        "arn:aws:sqs:*:*:dcp-matrix-notification-queue-${var.deployment_stage}"
+      ]
     }
   ]
 }

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -26,7 +26,8 @@ class MatrixTestCaseUsingMockAWS(unittest.TestCase):
 
     TEST_CONFIG = {
         'query_job_q_url': 'test_query_job_q_name',
-        'query_job_deadletter_q_url': 'test_deadletter_query_job_q_name'
+        'query_job_deadletter_q_url': 'test_deadletter_query_job_q_name',
+        'notification_q_url': 'test_notification_q_url'
     }
     TEST_REDSHIFT_CONFIG = {
         'database_uri': 'test_database_uri',
@@ -49,6 +50,7 @@ class MatrixTestCaseUsingMockAWS(unittest.TestCase):
         self.sqs = boto3.resource('sqs')
         self.sqs.create_queue(QueueName=f"test_query_job_q_name")
         self.sqs.create_queue(QueueName=f"test_deadletter_query_job_q_name")
+        self.sqs.create_queue(QueueName=f"test_notification_q_url")
 
     def tearDown(self):
         self.dynamo_mock.stop()

--- a/tests/unit/lambdas/api/test_core.py
+++ b/tests/unit/lambdas/api/test_core.py
@@ -9,7 +9,7 @@ from matrix.common.exceptions import MatrixException
 from matrix.common.aws.dynamo_handler import OutputTableField
 from matrix.common.aws.lambda_handler import LambdaName
 from matrix.common.aws.cloudwatch_handler import MetricName
-from matrix.lambdas.api.core import post_matrix, get_matrix, get_formats, dss_notification
+from matrix.lambdas.api.core import matrix_infra_config, post_matrix, get_matrix, get_formats, dss_notification
 
 
 class TestCore(unittest.TestCase):
@@ -197,8 +197,9 @@ class TestCore(unittest.TestCase):
         response = get_formats()
         self.assertEqual(response.body, [item.value for item in MatrixFormat])
 
-    @mock.patch("matrix.common.aws.lambda_handler.LambdaHandler.invoke")
-    def test_dss_notification(self, mock_lambda_invoke):
+    @mock.patch("matrix.common.aws.sqs_handler.SQSHandler.add_message_to_queue")
+    def test_dss_notification(self, mock_sqs_add):
+        matrix_infra_config.set({'notification_q_url': "notification_q_url"})
         body = {
             'subscription_id': "test_sub_id",
             'event_type': "test_event",
@@ -214,6 +215,6 @@ class TestCore(unittest.TestCase):
         }
 
         resp = dss_notification(body)
-        mock_lambda_invoke.assert_called_once_with(LambdaName.NOTIFICATION, expected_payload)
+        mock_sqs_add.assert_called_once_with("notification_q_url", expected_payload)
 
         self.assertEqual(resp.status_code, requests.codes.ok)


### PR DESCRIPTION
This is related to #227. It adds sqs/dlq between the matrix service api and the notification lambda. It also adds a functional test that tests the /dss/notification endpoint