### PR TITLE
Fix redshift serializable errors during concurrent notifications

### DIFF
--- a/matrix/common/constants.py
+++ b/matrix/common/constants.py
@@ -129,5 +129,11 @@ CREATE_QUERY_TEMPLATE = {
             cont_institution      VARCHAR(150),
             PRIMARY KEY(projectkey)
         ) DISTSTYLE ALL;
+    """,
+    'write_lock': """
+        CREATE TABLE IF NOT EXISTS {2} (
+            primarykey            VARCHAR(60) NOT NULL,
+            PRIMARY KEY(primarykey)
+        );
     """
 }


### PR DESCRIPTION
`CREATE` notifications update all tables in a single transaction to support rollback on failure. Concurrent notifications can potentially violate [Serializable Isolation](https://docs.aws.amazon.com/redshift/latest/dg/c_serial_isolation.html). These changes introduce an artificial write lock during notification processing or data loading that does not block read operations.

Alternatively locking the actual tables would block READs and affect request processing times - in this implementation, SELECTs will be executed on the last snapshot of the tables being written to.