### PR TITLE
Better error reporting for batch failure and timeouts

### DIFF
--- a/config/iam_policy_templates/matrix-service-api-lambda.json
+++ b/config/iam_policy_templates/matrix-service-api-lambda.json
@@ -63,6 +63,15 @@
       "Resource": [
         "arn:aws:secretsmanager:us-east-1:${account_id}:secret:dcp/matrix/${DEPLOYMENT_STAGE}/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "batch:Describe*"
+      ],
+      "Resource": [
+        "*"
+      ]
     }
   ]
 }

--- a/matrix/common/aws/batch_handler.py
+++ b/matrix/common/aws/batch_handler.py
@@ -1,11 +1,11 @@
 import os
 
 import boto3
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from matrix.common.aws.dynamo_handler import DynamoTable
 from matrix.common.constants import MatrixFormat
 from matrix.common.logging import Logging
-from matrix.common.aws.cloudwatch_handler import CloudwatchHandler, MetricName
 
 logger = Logging.get_logger(__name__)
 
@@ -18,8 +18,8 @@ class BatchHandler:
         self.job_def_arn = os.environ['BATCH_CONVERTER_JOB_DEFINITION_ARN']
 
         self._client = boto3.client("batch", region_name=os.environ['AWS_DEFAULT_REGION'])
-        self._cloudwatch_handler = CloudwatchHandler()
 
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
     def schedule_matrix_conversion(self, request_id: str, format: str):
         """
         Schedule a matrix conversion job within aws batch infra
@@ -53,15 +53,19 @@ class BatchHandler:
             'DYNAMO_OUTPUT_TABLE_NAME': DynamoTable.OUTPUT_TABLE.value,
         }
 
-        self._enqueue_batch_job(job_name=job_name,
-                                job_queue_arn=self.job_queue_arn,
-                                job_def_arn=self.job_def_arn,
-                                command=command,
-                                environment=environment)
-        self._cloudwatch_handler.put_metric_data(
-            metric_name=MetricName.CONVERSION_REQUEST,
-            metric_value=1
-        )
+        batch_job_id = self._enqueue_batch_job(job_name=job_name,
+                                               job_queue_arn=self.job_queue_arn,
+                                               job_def_arn=self.job_def_arn,
+                                               command=command,
+                                               environment=environment)
+        return batch_job_id
+
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(5))
+    def get_batch_job_status(self, batch_job_id):
+        response = self._client.describe_jobs(jobs=[batch_job_id])
+        jobs = response.get("jobs")
+        status = jobs[0]["status"]
+        return status
 
     def _enqueue_batch_job(self, job_name, job_queue_arn, job_def_arn, command, environment):
         job = self._client.submit_job(

--- a/matrix/common/aws/dynamo_handler.py
+++ b/matrix/common/aws/dynamo_handler.py
@@ -174,20 +174,11 @@ class DynamoHandler:
           field_value: Value to set for field
         """
         field_enum_value = field_enum.value
-        while True:
-            try:
-                table.update_item(
-                    Key=key_dict,
-                    UpdateExpression=f"SET {field_enum_value} = :n",
-                    ExpressionAttributeValues={":n": field_value}
-                )
-                break
-            except botocore.exceptions.ClientError as exc:
-                if exc.response['Error']['Code'] == "ConditionalCheckFailedException":
-                    pass
-                else:
-                    raise
-            time.sleep(.5)
+        table.update_item(
+            Key=key_dict,
+            UpdateExpression=f"SET {field_enum_value} = :n",
+            ExpressionAttributeValues={":n": field_value}
+        )
 
     def _increment_field(self, table, key_dict: dict, field_enum: TableField, increment_size: int):
         """Increment a value in a dynamo table safely.

--- a/matrix/common/request/request_tracker.py
+++ b/matrix/common/request/request_tracker.py
@@ -262,7 +262,3 @@ class RequestTracker:
                                                        self.request_id,
                                                        StateTableField.BATCH_JOB_ID,
                                                        batch_job_id)
-        self.cloudwatch_handler.put_metric_data(
-            metric_name=MetricName.CONVERSION_REQUEST,
-            metric_value=1
-        )

--- a/matrix/docker/query_runner.py
+++ b/matrix/docker/query_runner.py
@@ -60,7 +60,8 @@ class QueryRunner:
 
                     if request_tracker.is_request_ready_for_conversion():
                         logger.info("Scheduling batch conversion job")
-                        self.batch_handler.schedule_matrix_conversion(request_id, request_tracker.format)
+                        batch_job_id = self.batch_handler.schedule_matrix_conversion(request_id, request_tracker.format)
+                        request_tracker.write_batch_job_id_to_db(batch_job_id)
                 except Exception as e:
                     logger.info(f"QueryRunner failed on {message} with error {e}")
                     request_tracker.log_error(str(e))

--- a/tests/unit/common/aws/test_batch_handler.py
+++ b/tests/unit/common/aws/test_batch_handler.py
@@ -6,7 +6,6 @@ from unittest import mock
 from botocore.stub import Stubber
 
 from matrix.common.aws.batch_handler import BatchHandler
-from matrix.common.aws.cloudwatch_handler import MetricName
 
 
 class TestBatchHandler(unittest.TestCase):
@@ -17,14 +16,12 @@ class TestBatchHandler(unittest.TestCase):
         self.batch_handler = BatchHandler()
         self.mock_batch_client = Stubber(self.batch_handler._client)
 
-    @mock.patch("matrix.common.aws.cloudwatch_handler.CloudwatchHandler.put_metric_data")
     @mock.patch("matrix.common.aws.batch_handler.BatchHandler._enqueue_batch_job")
-    def test_schedule_matrix_conversion(self, mock_enqueue_batch_job, mock_cw_put):
+    def test_schedule_matrix_conversion(self, mock_enqueue_batch_job):
         format = "test_format"
         job_name = f"conversion-{os.environ['DEPLOYMENT_STAGE']}-{self.request_id}-{format}"
 
         self.batch_handler.schedule_matrix_conversion(self.request_id, format)
-        mock_cw_put.assert_called_once_with(metric_name=MetricName.CONVERSION_REQUEST, metric_value=1)
         mock_enqueue_batch_job.assert_called_once_with(job_name=job_name,
                                                        job_queue_arn=os.environ['BATCH_CONVERTER_JOB_QUEUE_ARN'],
                                                        job_def_arn=os.environ['BATCH_CONVERTER_JOB_DEFINITION_ARN'],
@@ -49,3 +46,24 @@ class TestBatchHandler(unittest.TestCase):
         self.mock_batch_client.activate()
 
         self.batch_handler._enqueue_batch_job("test_job_name", "test_job_queue", "test_job_definition", [], {})
+
+    def test_get_batch_job_status(self):
+        expected_params = {
+            'jobs': ['123']
+        }
+        expected_response = {
+            'jobs': [{
+                'status': "FAILED",
+                'jobName': "test_job_name",
+                'jobId': "test_job_id",
+                'jobQueue': "test_job_queue",
+                'startedAt': 123,
+                'jobDefinition': "test_job_definition"
+            }]
+        }
+        self.mock_batch_client.add_response('describe_jobs', expected_response, expected_params)
+        self.mock_batch_client.activate()
+
+        status = self.batch_handler.get_batch_job_status('123')
+
+        self.assertEqual(status, 'FAILED')

--- a/tests/unit/common/aws/test_batch_handler.py
+++ b/tests/unit/common/aws/test_batch_handler.py
@@ -6,6 +6,7 @@ from unittest import mock
 from botocore.stub import Stubber
 
 from matrix.common.aws.batch_handler import BatchHandler
+from matrix.common.aws.cloudwatch_handler import MetricName
 
 
 class TestBatchHandler(unittest.TestCase):
@@ -16,8 +17,9 @@ class TestBatchHandler(unittest.TestCase):
         self.batch_handler = BatchHandler()
         self.mock_batch_client = Stubber(self.batch_handler._client)
 
+    @mock.patch("matrix.common.aws.cloudwatch_handler.CloudwatchHandler.put_metric_data")
     @mock.patch("matrix.common.aws.batch_handler.BatchHandler._enqueue_batch_job")
-    def test_schedule_matrix_conversion(self, mock_enqueue_batch_job):
+    def test_schedule_matrix_conversion(self, mock_enqueue_batch_job, mock_cw_put):
         format = "test_format"
         job_name = f"conversion-{os.environ['DEPLOYMENT_STAGE']}-{self.request_id}-{format}"
 
@@ -27,6 +29,7 @@ class TestBatchHandler(unittest.TestCase):
                                                        job_def_arn=os.environ['BATCH_CONVERTER_JOB_DEFINITION_ARN'],
                                                        command=mock.ANY,
                                                        environment=mock.ANY)
+        mock_cw_put.assert_called_once_with(metric_name=MetricName.CONVERSION_REQUEST, metric_value=1)
 
     def test_enqueue_batch_job(self):
         expected_params = {

--- a/tests/unit/common/aws/test_dynamo_handler.py
+++ b/tests/unit/common/aws/test_dynamo_handler.py
@@ -88,6 +88,16 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.assertEqual(entry[StateTableField.COMPLETED_DRIVER_EXECUTIONS.value], 5)
         self.assertEqual(entry[StateTableField.COMPLETED_CONVERTER_EXECUTIONS.value], 0)
 
+    def test_set_table_field_with_value(self):
+        self.handler.create_state_table_entry(self.request_id)
+        response, entry = self._get_state_table_response_and_entry()
+        self.assertEqual(entry[StateTableField.BATCH_JOB_ID.value], "N/A")
+
+        field_enum = StateTableField.BATCH_JOB_ID
+        self.handler.set_table_field_with_value(DynamoTable.STATE_TABLE, self.request_id, field_enum, "123-123")
+        response, entry = self._get_state_table_response_and_entry()
+        self.assertEqual(entry[StateTableField.BATCH_JOB_ID.value], "123-123")
+
     def test_increment_table_field_output_table_path(self):
         self.handler.create_output_table_entry(self.request_id, 1, self.format)
 
@@ -111,6 +121,17 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         response, entry = self._get_state_table_response_and_entry()
         self.assertEqual(entry[StateTableField.COMPLETED_DRIVER_EXECUTIONS.value], 15)
         self.assertEqual(entry[StateTableField.COMPLETED_CONVERTER_EXECUTIONS.value], 0)
+
+    def test_set_field(self):
+        self.handler.create_state_table_entry(self.request_id)
+        response, entry = self._get_state_table_response_and_entry()
+        self.assertEqual(entry[StateTableField.BATCH_JOB_ID.value], "N/A")
+
+        key_dict = {"RequestId": self.request_id}
+        field_enum = StateTableField.BATCH_JOB_ID
+        self.handler._set_field(self.handler._state_table, key_dict, field_enum, "123-123")
+        response, entry = self._get_state_table_response_and_entry()
+        self.assertEqual(entry[StateTableField.BATCH_JOB_ID.value], "123-123")
 
     def test_get_state_table_entry(self):
         self.handler.create_state_table_entry(self.request_id)
@@ -140,10 +161,3 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.handler.create_output_table_entry(self.request_id, 1, self.format)
         entry = self.handler.get_table_item(DynamoTable.OUTPUT_TABLE, request_id=self.request_id)
         self.assertEqual(entry[OutputTableField.ROW_COUNT.value], 0)
-
-    def test_write_request_error(self):
-        self.handler.create_output_table_entry(self.request_id, 1, self.format)
-
-        self.handler.write_request_error(self.request_id, "test error")
-        output = self.handler.get_table_item(DynamoTable.OUTPUT_TABLE, request_id=self.request_id)
-        self.assertEqual(output[OutputTableField.ERROR_MESSAGE.value], "test error")

--- a/tests/unit/common/request/test_request_tracker.py
+++ b/tests/unit/common/request/test_request_tracker.py
@@ -159,12 +159,10 @@ class TestRequestTracker(MatrixTestCaseUsingMockAWS):
         self.assertTrue(self.request_tracker.timeout)
         mock_log_error.assert_called_once()
 
-    @mock.patch("matrix.common.aws.cloudwatch_handler.CloudwatchHandler.put_metric_data")
     @mock.patch("matrix.common.aws.dynamo_handler.DynamoHandler.set_table_field_with_value")
-    def test_write_batch_job_id_to_db(self, mock_set_table_field_with_value, mock_cw_put):
+    def test_write_batch_job_id_to_db(self, mock_set_table_field_with_value):
         self.request_tracker.write_batch_job_id_to_db("123-123")
         mock_set_table_field_with_value.assert_called_once_with(DynamoTable.STATE_TABLE,
                                                                 self.request_id,
                                                                 StateTableField.BATCH_JOB_ID,
                                                                 "123-123")
-        mock_cw_put.assert_called_once_with(metric_name=MetricName.CONVERSION_REQUEST, metric_value=1)


### PR DESCRIPTION
This PR accomplishes ticket #248. 1) Adds back 12 hr timeout on jobs 2) Returns failed request status if the batch job is marked as failed (saves corresponding batch job id in state table) 3) Consolidates method to write strings to dynamo tables and removes method specific to writing errors to output table