### PR TITLE
Create transformer functional test harness

### DIFF
--- a/matrix/common/constants.py
+++ b/matrix/common/constants.py
@@ -25,6 +25,15 @@ class BundleType(Enum):
     CELLRANGER = "cellranger"
 
 
+MATRIX_ENV_TO_DSS_ENV = {
+    'predev': "prod",
+    'dev': "prod",
+    'integration': "integration",
+    'staging': "staging",
+    'prod': "prod",
+}
+
+
 CREATE_QUERY_TEMPLATE = {
     'cell': """
         CREATE {0}TABLE IF NOT EXISTS {2} (

--- a/matrix/common/constants.py
+++ b/matrix/common/constants.py
@@ -17,6 +17,14 @@ class MatrixRequestStatus(Enum):
     FAILED = "Failed"
 
 
+class BundleType(Enum):
+    """
+    Supported bundle types
+    """
+    SS2 = "ss2"
+    CELLRANGER = "cellranger"
+
+
 CREATE_QUERY_TEMPLATE = {
     'cell': """
         CREATE {0}TABLE IF NOT EXISTS {2} (

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -8,17 +8,9 @@ import s3fs
 
 from . import validation
 from .wait_for import WaitFor
-from matrix.common.constants import MatrixRequestStatus
+from matrix.common.constants import MATRIX_ENV_TO_DSS_ENV, MatrixRequestStatus
 from matrix.common.aws.redshift_handler import RedshiftHandler
 
-
-MATRIX_ENV_TO_DSS_ENV = {
-    'predev': "prod",
-    'dev': "prod",
-    'integration': "integration",
-    'staging': "staging",
-    'prod': "prod",
-}
 
 INPUT_BUNDLE_IDS = {
     "integration": [

--- a/tests/functional/transformers/__init__.py
+++ b/tests/functional/transformers/__init__.py
@@ -1,0 +1,100 @@
+from matrix.common.aws.redshift_handler import TableName
+from matrix.common.constants import BundleType
+
+
+ETL_TEST_BUNDLES = {
+    'integration': {
+        BundleType.SS2: {
+            '5cb665f4-97bb-4176-8ec2-1b83b95c1bc0': {
+                TableName.ANALYSIS: "5f7dee36-68e8-41c8-9e5f-50f3c772176a|"
+                                    "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z|"
+                                    "smartseq2_v2.2.0|blessed",
+                TableName.SPECIMEN: "ca71bc0a-977d-4825-9ead-9e5741afe8e3|NCBITAXON:9606|Homo sapiens|HANCESTRO:0016|"
+                                    "African American or Afro-Caribbean|MONDO:0011273|H syndrome|EFO:0001272|adult|"
+                                    "UBERON:0002113|kidney|UBERON:0014451|tongue taste bud",
+                TableName.LIBRARY_PREPARATION: "84dd5dd7-cad0-4874-a36e-d2ca7e9d1489|OBI:0000869|polyA RNA extract|"
+                                               "EFO:0008931|Smart-seq2|full length|unstranded",
+                TableName.PROJECT: "1f6aecb3-09a0-432b-bece-d2790da570d6|integration/Smart-seq2/2019-02-11T16:26:25Z|"
+                                   "SS2 1 Cell Integration Test",
+                TableName.PUBLICATION: "1f6aecb3-09a0-432b-bece-d2790da570d6|Study of single cells in the human body|"
+                                       "10.1016/j.cell.2016.07.054",
+                TableName.CONTRIBUTOR: "1f6aecb3-09a0-432b-bece-d2790da570d6|John,D,Doe|EMBL-EBI",
+                TableName.CELL: "2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|"
+                                "1f6aecb3-09a0-432b-bece-d2790da570d6|ca71bc0a-977d-4825-9ead-9e5741afe8e3|"
+                                "84dd5dd7-cad0-4874-a36e-d2ca7e9d1489|5f7dee36-68e8-41c8-9e5f-50f3c772176a||3859\n",
+                TableName.EXPRESSION: "2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|ENST00000373020|TPM|92.29\n"
+            },
+        },
+        BundleType.CELLRANGER: {
+            'baed2abb-bf4a-4239-a605-38c7a1129596': {
+                TableName.ANALYSIS: "0603fcfc-a3eb-4442-a6bc-ed4495f0362c|"
+                                    "baed2abb-bf4a-4239-a605-38c7a1129596.2019-01-07T214226.767214Z|"
+                                    "cellranger_v1.0.2|community",
+                TableName.SPECIMEN: "f1bf7167-5948-4d55-9090-1f30a39fc564|NCBITAXON:9606|Homo sapiens|HANCESTRO:0005|"
+                                    "European|MONDO:0001932|atrophic vulva|||UBERON:0000955|brain|UBERON:0001876|"
+                                    "amygdala",
+                TableName.LIBRARY_PREPARATION: "7fa4f1e6-fa10-46eb-88e8-ebdadbf3eeab|OBI:0000869|polyA RNA extract|"
+                                               "EFO:0009310|10X v2 sequencing|full length|unstranded",
+                TableName.PROJECT: "9080b7a6-e1e9-45e4-a68e-353cd1438a0f|Q4_DEMO-project_PRJNA248302|"
+                                   "Q4_DEMO-Single cell RNA-seq of primary human glioblastomas",
+                TableName.PUBLICATION: "9080b7a6-e1e9-45e4-a68e-353cd1438a0f|A title of a publication goes here.|"
+                                       "10.1016/j.cell.2016.07.054",
+                TableName.CONTRIBUTOR: "9080b7a6-e1e9-45e4-a68e-353cd1438a0f|John,D,Doe. |EMBL-EBI",
+                TableName.CELL: "f066ea23371d725f8ec3868382ca1cc1|021d111b-4941-4e33-a2d1-8c3478f0cbd7|"
+                                "9080b7a6-e1e9-45e4-a68e-353cd1438a0f|f1bf7167-5948-4d55-9090-1f30a39fc564|"
+                                "7fa4f1e6-fa10-46eb-88e8-ebdadbf3eeab|0603fcfc-a3eb-4442-a6bc-ed4495f0362c|"
+                                "TGAGCATAGTACGATA-1|148\n",
+                TableName.EXPRESSION: "488dc8c5ce601b9833aad68b22cdae0e|ENSG00000198786|Count|2\n"
+            },
+        }
+    },
+    'staging': {
+        BundleType.SS2: {},
+        BundleType.CELLRANGER: {}
+    },
+    'prod': {
+        BundleType.SS2: {
+            'fff2cdde-4bd0-456f-93fc-5da18754272f': {
+                TableName.ANALYSIS: "29c35608-fbb4-43da-acf8-f87357f0dba3|"
+                                    "fff2cdde-4bd0-456f-93fc-5da18754272f.2019-02-01T193806.576719Z|"
+                                    "smartseq2_v2.2.0|blessed",
+                TableName.SPECIMEN: "31631609-4a44-4a39-a2ec-06632b3fa26d|NCBITAXON:9606|Homo sapiens|||"
+                                    "PATO:0000461|normal|EFO:0001272|adult|UBERON:0002450|decidua||",
+                TableName.LIBRARY_PREPARATION: "edda2708-1172-47f0-9c8b-b6771f463db1|OBI:0000869|polyA RNA extract|"
+                                               "EFO:0008931|Smart-seq2|full length|unstranded",
+                TableName.PROJECT: "aabbec1a-1215-43e1-8e42-6489af25c12c|Fetal/Maternal Interface|"
+                                   "Reconstructing the human first trimester fetal-maternal interface "
+                                   "using single cell transcriptomics",
+                TableName.PUBLICATION: "aabbec1a-1215-43e1-8e42-6489af25c12c|"
+                                       "Reconstructing the human first trimester fetal-maternal interface "
+                                       "using single cell transcriptomics|10.1101/429589",
+                TableName.CONTRIBUTOR: "aabbec1a-1215-43e1-8e42-6489af25c12c|Roser,,Vento-Tormo|"
+                                       "Wellcome Trust Sanger Institute",
+                TableName.CELL: "40ace1d6-bec8-4186-898b-d6aebbb1af82|40ace1d6-bec8-4186-898b-d6aebbb1af82|"
+                                "aabbec1a-1215-43e1-8e42-6489af25c12c|31631609-4a44-4a39-a2ec-06632b3fa26d|"
+                                "edda2708-1172-47f0-9c8b-b6771f463db1|29c35608-fbb4-43da-acf8-f87357f0dba3||6132\n",
+                TableName.EXPRESSION: "40ace1d6-bec8-4186-898b-d6aebbb1af82|ENST00000371588|TPM|69.86\n"
+            },
+        },
+        BundleType.CELLRANGER: {
+            'feea80a7-ec5b-4b20-9e14-7b45676875e5': {
+                TableName.ANALYSIS: "a7a93615-a8f7-4e2d-8f3f-62e79841a3f7|"
+                                    "feea80a7-ec5b-4b20-9e14-7b45676875e5.2018-12-12T235115.759620Z|"
+                                    "cellranger_v1.0.2|community",
+                TableName.SPECIMEN: "3902d552-081a-4e9d-83a4-0f8ea0f5b74c|NCBITAXON:9606|Homo sapiens|HANCESTRO:0005|"
+                                    "European|||EFO:0001272|adult|UBERON:0002405|immune system|UBERON:0002371|"
+                                    "bone marrow",
+                TableName.LIBRARY_PREPARATION: "6f367bb6-7fc6-4099-a053-005f38e690cb|OBI:0000869|polyA RNA extract|"
+                                               "EFO:0009310|10X v2 sequencing|3 prime tag|second",
+                TableName.PROJECT: "179bf9e6-5b33-4c5b-ae26-96c7270976b8|1M Immune Cells|Census of Immune Cells",
+                TableName.PUBLICATION: None,
+                TableName.CONTRIBUTOR: "179bf9e6-5b33-4c5b-ae26-96c7270976b8|Julia,,Waldman|Broad Institute",
+                TableName.CELL: "fed3f59022cac456e769e8a063829e0e|12befbdf-9bb8-44cc-886a-623a5e656604|"
+                                "179bf9e6-5b33-4c5b-ae26-96c7270976b8|3902d552-081a-4e9d-83a4-0f8ea0f5b74c|"
+                                "6f367bb6-7fc6-4099-a053-005f38e690cb|a7a93615-a8f7-4e2d-8f3f-62e79841a3f7|"
+                                "GATTCAGGTGCACTTA-1|634\n",
+                TableName.EXPRESSION: "c78f796e986ae508373972d00f54ecbd|ENSG00000198727|Count|4\n"
+            }
+        }
+    }
+}

--- a/tests/functional/transformers/test_transformers.py
+++ b/tests/functional/transformers/test_transformers.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import unittest
 
-from matrix.common.constants import BundleType
+from matrix.common.constants import MATRIX_ENV_TO_DSS_ENV, BundleType
 from matrix.common.etl import run_etl
 from matrix.common.etl.transformers.analysis import AnalysisTransformer
 from matrix.common.etl.transformers.cell_expression import CellExpressionTransformer
@@ -21,9 +21,7 @@ logger = Logging.get_logger(__name__)
 
 class TestTransformers(unittest.TestCase):
     DEPLOYMENT_STAGE = os.environ['DEPLOYMENT_STAGE']
-    DSS_STAGE = ("prod"
-                 if DEPLOYMENT_STAGE == "prod" or DEPLOYMENT_STAGE == "predev" or DEPLOYMENT_STAGE == "dev"
-                 else DEPLOYMENT_STAGE)
+    DSS_STAGE = MATRIX_ENV_TO_DSS_ENV[DEPLOYMENT_STAGE]
     TRANSFORMERS = [
         AnalysisTransformer,
         CellExpressionTransformer,

--- a/tests/functional/transformers/test_transformers.py
+++ b/tests/functional/transformers/test_transformers.py
@@ -1,0 +1,103 @@
+import concurrent.futures
+import os
+import shutil
+import unittest
+
+from matrix.common.constants import BundleType
+from matrix.common.etl import run_etl
+from matrix.common.etl.transformers.analysis import AnalysisTransformer
+from matrix.common.etl.transformers.cell_expression import CellExpressionTransformer
+from matrix.common.etl.transformers.project_publication_contributor import ProjectPublicationContributorTransformer
+from matrix.common.etl.transformers.specimen_library import SpecimenLibraryTransformer
+from matrix.common.logging import Logging
+from tests.functional.transformers import ETL_TEST_BUNDLES
+from tests.functional.transformers.validation import (AnalysisValidator,
+                                                      CellExpressionValidator,
+                                                      ProjectPublicationContributorValidator,
+                                                      SpecimenLibraryValidator)
+
+logger = Logging.get_logger(__name__)
+
+
+class TestTransformers(unittest.TestCase):
+    DEPLOYMENT_STAGE = os.environ['DEPLOYMENT_STAGE']
+    DSS_STAGE = ("prod"
+                 if DEPLOYMENT_STAGE == "prod" or DEPLOYMENT_STAGE == "predev" or DEPLOYMENT_STAGE == "dev"
+                 else DEPLOYMENT_STAGE)
+    TRANSFORMERS = [
+        AnalysisTransformer,
+        CellExpressionTransformer,
+        ProjectPublicationContributorTransformer,
+        SpecimenLibraryTransformer
+    ]
+    VALIDATORS = {
+        'AnalysisTransformer': AnalysisValidator,
+        'CellExpressionTransformer': CellExpressionValidator,
+        'ProjectPublicationContributorTransformer': ProjectPublicationContributorValidator,
+        'SpecimenLibraryTransformer': SpecimenLibraryValidator
+    }
+    OUTPUT_DIR = os.path.abspath("./tests/functional/res/etl/test_transformers_output")
+    TEST_BUNDLES = ETL_TEST_BUNDLES[DSS_STAGE]
+
+    @classmethod
+    def setUpClass(cls):
+        os.makedirs(TestTransformers.OUTPUT_DIR, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        TestTransformers._cleanup()
+
+    def test_transformers(self):
+        for btype in BundleType:
+            for bundle_uuid in self.TEST_BUNDLES[btype]:
+                TestTransformers.setUpClass()
+                logger.info(f"Testing ETL transformers for {btype} bundle {bundle_uuid}")
+                self._download_bundle(bundle_uuid)
+                self._transform_and_validate(bundle_uuid,
+                                             btype,
+                                             expected_rows=self.TEST_BUNDLES[btype][bundle_uuid])
+                TestTransformers._cleanup()
+
+    @staticmethod
+    def _transform_and_validate(bundle_uuid: str, btype: BundleType, expected_rows: dict):
+        bundles_dir = os.path.join(TestTransformers.OUTPUT_DIR, "bundles")
+        bundle_dir = os.path.join(bundles_dir, os.listdir(bundles_dir)[0])
+
+        for transformer_class in TestTransformers.TRANSFORMERS:
+            transformer = transformer_class(bundle_dir)
+            logger.info(f"Testing {transformer.__class__.__name__} on {bundle_uuid}")
+
+            actual_rows = transformer._parse_from_metadatas(bundle_dir)
+
+            validator = TestTransformers.VALIDATORS[transformer.__class__.__name__]()
+            validator.validate(actual_rows, expected_rows, btype)
+
+    @staticmethod
+    def _download_bundle(bundle_uuid: str):
+        logger.info(f"Downloading bundle {bundle_uuid}")
+
+        query = {
+            "query": {
+                "bool": {
+                    "must": [{"term": {"uuid": bundle_uuid}}]
+                }
+            }
+        }
+        content_type_patterns = ['application/json; dcp-type="metadata*"']
+        filename_patterns = ["*zarr*",  # match expression data
+                             "*.results",  # match SS2 results files
+                             "*.mtx", "genes.tsv", "barcodes.tsv"]  # match 10X results files
+
+        run_etl(query=query,
+                content_type_patterns=content_type_patterns,
+                filename_patterns=filename_patterns,
+                transformer_cb=None,
+                finalizer_cb=None,
+                staging_directory=os.path.abspath(TestTransformers.OUTPUT_DIR),
+                deployment_stage=TestTransformers.DEPLOYMENT_STAGE,
+                max_workers=4,
+                dispatcher_executor_class=concurrent.futures.ThreadPoolExecutor)
+
+    @staticmethod
+    def _cleanup():
+        shutil.rmtree(TestTransformers.OUTPUT_DIR, ignore_errors=True)

--- a/tests/functional/transformers/validation.py
+++ b/tests/functional/transformers/validation.py
@@ -1,0 +1,50 @@
+import unittest
+import typing
+
+from matrix.common.aws.redshift_handler import TableName
+from matrix.common.constants import BundleType
+
+
+class TransformerValidator(unittest.TestCase):
+    def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
+        raise NotImplementedError()
+
+
+class AnalysisValidator(TransformerValidator):
+    def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
+        analysis_rows = actual_rows[0][1]
+        self.assertTrue(expected_rows[TableName.ANALYSIS] in analysis_rows)
+
+
+class CellExpressionValidator(TransformerValidator):
+    def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
+        cell_rows = actual_rows[0][1]
+        if bundle_type == BundleType.SS2:
+            self.assertEqual(cell_rows[0], expected_rows[TableName.CELL])
+        elif bundle_type == BundleType.CELLRANGER:
+            self.assertTrue(expected_rows[TableName.CELL] in cell_rows)
+
+        expression_rows = actual_rows[1][1]
+        self.assertEqual(expression_rows[0], expected_rows[TableName.EXPRESSION])
+
+
+class ProjectPublicationContributorValidator(TransformerValidator):
+    def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
+        project_rows = actual_rows[0][1]
+        self.assertTrue(expected_rows[TableName.PROJECT] in project_rows)
+
+        contributor_rows = actual_rows[1][1]
+        self.assertTrue(expected_rows[TableName.CONTRIBUTOR] in contributor_rows)
+
+        publication_rows = actual_rows[2][1]
+        if expected_rows[TableName.PUBLICATION]:
+            self.assertTrue(expected_rows[TableName.PUBLICATION] in publication_rows)
+
+
+class SpecimenLibraryValidator(TransformerValidator):
+    def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
+        specimen_rows = actual_rows[0][1]
+        self.assertTrue(expected_rows[TableName.SPECIMEN] in specimen_rows)
+
+        library_rows = actual_rows[1][1]
+        self.assertTrue(expected_rows[TableName.LIBRARY_PREPARATION] in library_rows)

--- a/tests/functional/transformers/validation.py
+++ b/tests/functional/transformers/validation.py
@@ -13,7 +13,16 @@ class TransformerValidator(unittest.TestCase):
 class AnalysisValidator(TransformerValidator):
     def validate(self, actual_rows: typing.Tuple, expected_rows: dict, bundle_type: BundleType):
         analysis_rows = actual_rows[0][1]
-        self.assertTrue(expected_rows[TableName.ANALYSIS] in analysis_rows)
+
+        # assumes 1 analysis row per bundle
+        actual_vals = next(iter(analysis_rows)).split("|")
+        expected_vals = expected_rows[TableName.ANALYSIS].split("|")
+
+        # ignore bundle_fqid as version may change
+        actual_vals.pop(1)
+        expected_vals.pop(1)
+
+        self.assertEqual(actual_vals, expected_vals)
 
 
 class CellExpressionValidator(TransformerValidator):


### PR DESCRIPTION
These functional tests enable the verification of transformer output (PSV) for individual bundles by:
1. Downloading the bundle's metadata and analysis results via the ETL library
2. Executing `matrix.common.etl.transformers` on bundle data
3. Verifying transformer output (PSV strings) against `tests.functional.transformers.__init__.py`
4. Delete downloaded bundles

Test bundles used in (3) will be selected to include 1 bundle from each matrixable dataset. This harness will enable us to perform integration tests against metadata schema changes as datasets are re-ingested per environment. 