### PR TITLE
log transform errors during ETL

### DIFF
--- a/matrix/common/etl/__init__.py
+++ b/matrix/common/etl/__init__.py
@@ -148,11 +148,11 @@ def _log_error(entity: str, exception: Exception, trace: str, extractor: DSSExtr
     timestamp = date.get_datetime_now(as_string=True)
     log_file_path = os.path.join(extractor.sd, MetadataToPsvTransformer.LOG_DIRNAME, 'errors.txt')
     with open(log_file_path, 'a+') as fh:
-        fh.write(f"[{timestamp}] {entity} failed with exception: {exception}\n")
+        fh.write(f"[{timestamp}] {entity} failed with exception: {exception}\n{trace}\n")
 
-    exceptions_file_path = os.path.join(extractor.sd, MetadataToPsvTransformer.LOG_DIRNAME, 'exceptions.txt')
-    with open(exceptions_file_path, 'a+') as fh:
-        fh.write(f"[{timestamp}] {trace}\n")
+    ft_file_path = os.path.join(extractor.sd, MetadataToPsvTransformer.LOG_DIRNAME, 'failed_transforms.txt')
+    with open(ft_file_path, 'a+') as fh:
+        fh.write(f"{entity}\n")
 
 
 def load_from_local_files(staging_dir, is_update: bool=False):

--- a/matrix/common/etl/transformers/__init__.py
+++ b/matrix/common/etl/transformers/__init__.py
@@ -8,6 +8,7 @@ class MetadataToPsvTransformer:
     """
     PSV_EXT = ".psv"
     OUTPUT_DIRNAME = "output"
+    LOG_DIRNAME = "logs"
 
     def __init__(self, staging_dir):
         self.staging_dir = staging_dir

--- a/tests/unit/common/etl/test_etl.py
+++ b/tests/unit/common/etl/test_etl.py
@@ -170,8 +170,8 @@ class TestEtl(unittest.TestCase):
             _log_error("test_bundle", ex, "test_trace", extractor)
 
             handle = mock_open()
-            expected_calls = [mock.call("[timestamp] test_bundle failed with exception: msg\n"),
-                              mock.call("[timestamp] test_trace\n")]
+            expected_calls = [mock.call("[timestamp] test_bundle failed with exception: msg\ntest_trace\n"),
+                              mock.call("test_bundle\n")]
             handle.write.assert_has_calls(expected_calls)
             self.assertTrue(mock_error.called)
 

--- a/tests/unit/common/etl/test_etl.py
+++ b/tests/unit/common/etl/test_etl.py
@@ -12,6 +12,7 @@ from matrix.common.etl import (run_etl,
                                transform_bundle,
                                finalizer_reload,
                                finalizer_update,
+                               _log_error,
                                load_from_local_files,
                                load_from_s3,
                                _upload_to_s3,
@@ -59,9 +60,9 @@ class TestEtl(unittest.TestCase):
                                              dispatch_executor_class=concurrent.futures.ProcessPoolExecutor)
 
     @mock.patch("hca.dss.DSSClient.swagger_spec", new_callable=mock.PropertyMock)
-    @mock.patch("matrix.common.etl.logger.error")
+    @mock.patch("matrix.common.etl._log_error")
     @mock.patch("matrix.common.etl.transformers.cell_expression.CellExpressionTransformer.transform")
-    def test_transform_bundle(self, mock_cell_expression_transform, mock_error, mock_swagger_spec):
+    def test_transform_bundle(self, mock_cell_expression_transform, mock_log_error, mock_swagger_spec):
         mock_swagger_spec.return_value = self.stub_swagger_spec
         extractor = DSSExtractor(staging_directory="test_dir",
                                  content_type_patterns=[],
@@ -74,11 +75,11 @@ class TestEtl(unittest.TestCase):
         e = Exception()
         mock_cell_expression_transform.side_effect = e
         transform_bundle("test_uuid", "test_version", "test_path", "test_manifest_path", extractor)
-        mock_error.assert_called_once_with("Failed to transform bundle test_uuid.test_version.", e)
+        mock_log_error.assert_called_once_with("test_uuid.test_version", e, extractor)
 
     @mock.patch("hca.dss.DSSClient.swagger_spec", new_callable=mock.PropertyMock)
     @mock.patch("matrix.common.etl.load_from_local_files")
-    @mock.patch("matrix.common.etl.logger.error")
+    @mock.patch("matrix.common.etl._log_error")
     @mock.patch("matrix.common.etl.transformers."
                 "project_publication_contributor.ProjectPublicationContributorTransformer.transform")
     @mock.patch("matrix.common.etl.transformers.specimen_library.SpecimenLibraryTransformer.transform")
@@ -91,7 +92,7 @@ class TestEtl(unittest.TestCase):
                               mock_analysis_transformer,
                               mock_specimen_library_transformer,
                               mock_project_publication_contributor_transformer,
-                              mock_error,
+                              mock_log_error,
                               mock_load_from_local_files,
                               mock_swagger_spec):
         mock_swagger_spec.return_value = self.stub_swagger_spec
@@ -107,15 +108,16 @@ class TestEtl(unittest.TestCase):
         mock_project_publication_contributor_transformer.assert_called_once_with("test_dir/bundles")
         mock_load_from_local_files.assert_called_once_with("test_dir", is_update=False)
 
+        e = Exception()
         mock_load_from_local_files.reset_mock()
-        mock_feature_transformer.side_effect = Exception()
+        mock_feature_transformer.side_effect = e
         finalizer_reload(extractor)
-        self.assertTrue(mock_error.called)
+        mock_log_error.assert_called_once_with("FeatureTransformer", e, extractor)
         mock_load_from_local_files.assert_called_once_with("test_dir", is_update=False)
 
     @mock.patch("hca.dss.DSSClient.swagger_spec", new_callable=mock.PropertyMock)
     @mock.patch("matrix.common.etl.load_from_local_files")
-    @mock.patch("matrix.common.etl.logger.error")
+    @mock.patch("matrix.common.etl._log_error")
     @mock.patch("matrix.common.etl.transformers."
                 "project_publication_contributor.ProjectPublicationContributorTransformer.transform")
     @mock.patch("matrix.common.etl.transformers.specimen_library.SpecimenLibraryTransformer.transform")
@@ -128,7 +130,7 @@ class TestEtl(unittest.TestCase):
                               mock_analysis_transformer,
                               mock_specimen_library_transformer,
                               mock_project_publication_contributor_transformer,
-                              mock_error,
+                              mock_log_error,
                               mock_load_from_local_files,
                               mock_swagger_spec):
         mock_swagger_spec.return_value = self.stub_swagger_spec
@@ -144,11 +146,32 @@ class TestEtl(unittest.TestCase):
         mock_project_publication_contributor_transformer.assert_called_once_with("test_dir/bundles")
         mock_load_from_local_files.assert_called_once_with("test_dir", is_update=True)
 
+        e = Exception()
         mock_load_from_local_files.reset_mock()
-        mock_analysis_transformer.side_effect = Exception()
+        mock_analysis_transformer.side_effect = e
         finalizer_update(extractor)
-        self.assertTrue(mock_error.called)
+        mock_log_error.assert_called_once_with("AnalysisTransformer", e, extractor)
         mock_load_from_local_files.assert_called_once_with("test_dir", is_update=True)
+
+    @mock.patch("hca.dss.DSSClient.swagger_spec", new_callable=mock.PropertyMock)
+    @mock.patch("matrix.common.date.get_datetime_now")
+    @mock.patch("matrix.common.etl.logger.error")
+    def test_log_error(self, mock_error, mock_datetime_now, mock_swagger_spec):
+        mock_swagger_spec.return_value = self.stub_swagger_spec
+        mock_datetime_now.return_value = "timestamp"
+
+        ex = Exception("msg")
+        extractor = DSSExtractor(staging_directory="test_dir",
+                                 content_type_patterns=[],
+                                 filename_patterns=[],
+                                 dss_client=get_dss_client("dev"))
+
+        with mock.patch("builtins.open", mock.mock_open()) as mock_open:
+            _log_error("test_bundle", ex, extractor)
+
+            handle = mock_open()
+            handle.write.assert_called_once_with(f"[timestamp] test_bundle failed with exception: msg\n")
+            self.assertTrue(mock_error.called)
 
     @mock.patch("matrix.common.etl._populate_all_tables")
     @mock.patch("matrix.common.etl._upload_to_s3")


### PR DESCRIPTION
These changes log transformation errors in `logs/errors.txt` for further review. Cell and expression transforms are performed per bundle and will yield a `bundle_uuid.bundle_version` on failure, whereas all other transformers are performed against all bundles and will simply report if the transformer failed.