### PR TITLE
handle DSS update events

### DIFF
--- a/matrix/lambdas/daemons/notification.py
+++ b/matrix/lambdas/daemons/notification.py
@@ -21,7 +21,7 @@ class NotificationHandler:
         self.redshift = RedshiftHandler()
 
     def run(self):
-        if self.event_type == 'CREATE':
+        if self.event_type == 'CREATE' or self.event_type == 'UPDATE':
             self.update_bundle()
         elif self.event_type == 'DELETE' or self.event_type == 'TOMBSTONE':
             self.remove_bundle()

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -45,6 +45,8 @@ INPUT_BUNDLE_IDS = {
 NOTIFICATION_BUNDLE_IDS = {
     "integration": "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z",
     "staging": "119f6f39-d111-4c33-a3d5-224a67655b07.2018-10-24T224220.927365Z",
+    # notification test does not run on prod, however other matrix environments may point to dss prod
+    "prod": "fffe55c1-18ed-401b-aa9a-6f64d0b93fec.2019-05-17T233932.932000Z",
 }
 
 INPUT_BUNDLE_URL = \

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -42,6 +42,11 @@ INPUT_BUNDLE_IDS = {
     ]
 }
 
+NOTIFICATION_BUNDLE_IDS = {
+    "integration": "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z",
+    "staging": "119f6f39-d111-4c33-a3d5-224a67655b07.2018-10-24T224220.927365Z",
+}
+
 INPUT_BUNDLE_URL = \
     "https://s3.amazonaws.com/dcp-matrix-test-data/{dss_env}_test_bundles.tsv"
 
@@ -167,7 +172,7 @@ class TestMatrixServiceV0(MatrixServiceTest):
     @unittest.skipUnless(os.getenv('DEPLOYMENT_STAGE') != "prod",
                          "Do not want to process fake notifications in production.")
     def test_dss_notification(self):
-        bundle_fqid = INPUT_BUNDLE_IDS[self.dss_env][0]
+        bundle_fqid = NOTIFICATION_BUNDLE_IDS[self.dss_env]
         try:
             self._post_notification(bundle_fqid=bundle_fqid, event_type="DELETE")
             WaitFor(self._poll_db_get_row_counts_from_fqid, bundle_fqid)\

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -185,6 +185,10 @@ class TestMatrixServiceV0(MatrixServiceTest):
         WaitFor(self._poll_db_get_analysis_row_count_from_fqid, bundle_fqid)\
             .to_return_value(1, timeout_seconds=600)
 
+        self._post_notification(bundle_fqid=bundle_fqid, event_type="UPDATE")
+        WaitFor(self._poll_db_get_analysis_row_count_from_fqid, bundle_fqid) \
+            .to_return_value(1, timeout_seconds=600)
+
     @unittest.skip
     def test_matrix_service_ss2(self):
         timeout = int(os.getenv("MATRIX_TEST_TIMEOUT", 300))

--- a/tests/functional/wait_for.py
+++ b/tests/functional/wait_for.py
@@ -38,6 +38,19 @@ class WaitFor:
             raise RuntimeError(f"Function {self._function_signature()} did not return a non-{other_than_value} value " +
                                f"within {timeout_seconds} seconds")
 
+    def to_return_value_in_range(self, lower, upper, timeout_seconds=60):
+        self.start_time = time.time()
+        timeout_at = self.start_time + timeout_seconds
+
+        while time.time() < timeout_at:
+            retval = self._call_func()
+            if lower <= retval <= upper:
+                return retval
+            self._wait_until_next_check_time()
+        else:
+            raise RuntimeError(f"Function {self._function_signature()} did not return an int within range " +
+                               f"within {timeout_seconds} seconds")
+
     def _call_func(self):
         retval = self.func(*self.func_args)
         print(f"After {self._elapsed_time()}: {self._function_signature()} returned {retval}")

--- a/tests/unit/lambdas/daemons/test_notification.py
+++ b/tests/unit/lambdas/daemons/test_notification.py
@@ -19,6 +19,13 @@ class TestNotificationHandler(unittest.TestCase):
 
         mock_update_bundle.assert_called_once_with()
 
+    @mock.patch("matrix.lambdas.daemons.notification.NotificationHandler.update_bundle")
+    def test_update_event(self, mock_update_bundle):
+        handler = NotificationHandler(self.bundle_uuid, self.bundle_version, "UPDATE")
+        handler.run()
+
+        mock_update_bundle.assert_called_once_with()
+
     @mock.patch("matrix.lambdas.daemons.notification.NotificationHandler.remove_bundle")
     def test_delete_event(self, mock_remove_bundle):
         handler = NotificationHandler(self.bundle_uuid, self.bundle_version, "DELETE")


### PR DESCRIPTION
The ETL library queries on `bundle_uuid` and downloads the latest version. The notification handler will replace the old bundle in Redshift with the new bundle.

Closes #282 