### PR TITLE
Fix detail requests for fields in the cell table

### DIFF
--- a/matrix/lambdas/api/v1/core.py
+++ b/matrix/lambdas/api/v1/core.py
@@ -169,7 +169,7 @@ def _redshift_detail_lookup(name, description):
             fq_field_name=fq_name,
             table_name=table_name,
             primary_key=table_primary_key)
-        results = dict(rs_handler.transaction([query], return_results=True))
+        results = dict(rs_handler.transaction([query], return_results=True, read_only=True))
         if None in results:
             results[""] = results[None]
             results.pop(None)
@@ -185,7 +185,7 @@ def _redshift_detail_lookup(name, description):
             fq_field_name=fq_name,
             table_name=table_name,
             primary_key=table_primary_key)
-        results = rs_handler.transaction([query], return_results=True)
+        results = rs_handler.transaction([query], return_results=True, read_only=True)
         min_ = results[0][0]
         max_ = results[0][1]
         return ({

--- a/matrix/lambdas/api/v1/core.py
+++ b/matrix/lambdas/api/v1/core.py
@@ -165,10 +165,8 @@ def _redshift_detail_lookup(name, description):
     rs_handler = RedshiftHandler()
 
     if type_ == "categorical":
-        query = query_constructor.FIELD_DETAIL_CATEGORICAL_QUERY_TEMPLATE.format(
-            fq_field_name=fq_name,
-            table_name=table_name,
-            primary_key=table_primary_key)
+        query = query_constructor.create_field_detail_query(
+            fq_name, table_name, table_primary_key, type_)
         results = dict(rs_handler.transaction([query], return_results=True, read_only=True))
         if None in results:
             results[""] = results[None]
@@ -181,10 +179,8 @@ def _redshift_detail_lookup(name, description):
             requests.codes.ok)
 
     elif type_ == "numeric":
-        query = query_constructor.FIELD_DETAIL_NUMERIC_QUERY_TEMPLATE.format(
-            fq_field_name=fq_name,
-            table_name=table_name,
-            primary_key=table_primary_key)
+        query = query_constructor.create_field_detail_query(
+            fq_name, table_name, table_primary_key, type_)
         results = rs_handler.transaction([query], return_results=True, read_only=True)
         min_ = results[0][0]
         max_ = results[0][1]

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -380,3 +380,14 @@ class TestMatrixServiceV1(MatrixServiceTest):
         for bundle_fqid in INPUT_BUNDLE_IDS[self.dss_env]:
             self.assertIn(bundle_fqid, cell_counts)
             self.assertEqual(cell_counts[bundle_fqid], 1)
+
+    def test_filter_detail_in_cell_table(self):
+
+        response = self._make_request(description="GET REQUEST TO FILTER DETAIL",
+                                      verb='GET',
+                                      url=f"{self.api_url}/filters/genes_detected",
+                                      expected_status=200,
+                                      headers=self.headers)
+        response = json.loads(response.decode())
+        self.assertIn("minimum", response)
+        self.assertIn("maximum", response)

--- a/tests/unit/common/test_query_constructor.py
+++ b/tests/unit/common/test_query_constructor.py
@@ -451,3 +451,52 @@ MANIFEST VERBOSE
 ;
 """)
         self.assertEqual(queries["expression_query"], expected_exp_query)
+
+
+class TestDetailQuery(unittest.TestCase):
+
+    def test_cell_numeric(self):
+        query = query_constructor.create_field_detail_query(
+            "cell.genes_detected",
+            "cell",
+            "cellkey",
+            "numeric")
+
+        expected_sql = """
+SELECT MIN(cell.genes_detected), MAX(cell.genes_detected)
+FROM cell 
+;
+"""  # noqa: W291
+        self.assertEqual(query, expected_sql)
+
+    def test_cell_categorical(self):
+
+        query = query_constructor.create_field_detail_query(
+            "cell.cell_suspension_id",
+            "cell",
+            "cellkey",
+            "categorical")
+
+        expected_sql = """
+SELECT cell.cell_suspension_id, COUNT(cell.cellkey)
+FROM cell 
+GROUP BY cell.cell_suspension_id
+;
+"""  # noqa: W291
+        self.assertEqual(query, expected_sql)
+
+    def test_noncell_categorical(self):
+
+        query = query_constructor.create_field_detail_query(
+            "analysis.protocol",
+            "analysis",
+            "analysiskey",
+            "categorical")
+
+        expected_sql = """
+SELECT analysis.protocol, COUNT(cell.cellkey)
+FROM cell LEFT OUTER JOIN analysis on (cell.analysiskey = analysis.analysiskey)
+GROUP BY analysis.protocol
+;
+"""
+        self.assertEqual(query, expected_sql)


### PR DESCRIPTION
Previously, requests for details about a field in the cell table, like `genes_detected` for example, would generate sql with `...FROM cell LEFT OUTER JOIN cell...`. This fixes that.