### PR TITLE
check request bundles exist in matrix service db

### DIFF
--- a/terraform/modules/matrix-service/lambdas/driver_lambda.tf
+++ b/terraform/modules/matrix-service/lambdas/driver_lambda.tf
@@ -108,7 +108,7 @@ resource "aws_lambda_function" "matrix_service_driver_v0_lambda" {
   role             = "${aws_iam_role.matrix_service_driver_lambda.arn}"
   handler          = "app.driver_handler"
   runtime          = "python3.6"
-  timeout          = 300
+  timeout          = 900
 
   environment {
     variables = {

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -178,6 +178,13 @@ class TestMatrixServiceV0(MatrixServiceTest):
             .to_return_value(MatrixRequestStatus.COMPLETE.value, timeout_seconds=300)
         self._analyze_loom_matrix_results(self.request_id, INPUT_BUNDLE_IDS[self.dss_env])
 
+    def test_matrix_service_with_unexpected_bundles(self):
+        input_bundles = ['non-existent-bundle1', 'non-existent-bundle2']
+        self.request_id = self._post_matrix_service_request(
+            bundle_fqids=input_bundles)
+        WaitFor(self._poll_get_matrix_service_request, self.request_id)\
+            .to_return_value(MatrixRequestStatus.FAILED.value, timeout_seconds=300)
+
     @unittest.skipUnless(os.getenv('DEPLOYMENT_STAGE') != "prod",
                          "Do not want to process fake notifications in production.")
     def test_dss_notification(self):


### PR DESCRIPTION
This PR accomplishes #221. We will now return a failure in v0 driver if the request bundles do not all exist within our database (specifically the analysis table)