### PR TITLE
Update DELETE notification handler to support v1 API

### DIFF
--- a/matrix/common/query_constructor.py
+++ b/matrix/common/query_constructor.py
@@ -250,3 +250,7 @@ def filter_to_where(matrix_filter: typing.Dict[str, typing.Any]) -> str:
                 f"({filter_to_where(v)})" for v in value]) + ')'
     else:
         raise MalformedMatrixFilter(f"Invalid op: {op}")
+
+
+def list_to_query_str(values: typing.Iterable[str]) -> str:
+    return '(' + ', '.join("'" + str(v) + "'" for v in values) + ')'

--- a/matrix/common/query_constructor.py
+++ b/matrix/common/query_constructor.py
@@ -252,5 +252,10 @@ def filter_to_where(matrix_filter: typing.Dict[str, typing.Any]) -> str:
         raise MalformedMatrixFilter(f"Invalid op: {op}")
 
 
-def list_to_query_str(values: typing.Iterable[str]) -> str:
+def format_str_list(values: typing.Iterable[str]) -> str:
+    """
+    Formats a list of strings into a query compatible string
+    :param values: list of strings
+    :return: stringified list
+    """
     return '(' + ', '.join("'" + str(v) + "'" for v in values) + ')'

--- a/matrix/lambdas/daemons/v0/driver.py
+++ b/matrix/lambdas/daemons/v0/driver.py
@@ -10,6 +10,7 @@ from matrix.common.aws.dynamo_handler import DynamoHandler, DynamoTable, Request
 from matrix.common.aws.redshift_handler import RedshiftHandler
 from matrix.common.aws.sqs_handler import SQSHandler
 from matrix.common.aws.s3_handler import S3Handler
+from matrix.common.query_constructor import list_to_query_str
 
 logger = Logging.get_logger(__name__)
 
@@ -146,13 +147,13 @@ class Driver:
         exp_query = expression_query_template.format(self.query_results_bucket,
                                                      self.request_id,
                                                      self.redshift_role_arn,
-                                                     self._format_bundle_fqids(resolved_bundle_fqids))
+                                                     list_to_query_str(resolved_bundle_fqids))
         exp_query_obj_key = self.s3_handler.store_content_in_s3(f"{self.request_id}/expression", exp_query)
 
         cell_query = cell_query_template.format(self.query_results_bucket,
                                                 self.request_id,
                                                 self.redshift_role_arn,
-                                                self._format_bundle_fqids(resolved_bundle_fqids))
+                                                list_to_query_str(resolved_bundle_fqids))
         cell_query_obj_key = self.s3_handler.store_content_in_s3(f"{self.request_id}/cell", cell_query)
 
         return [feature_query_obj_key, exp_query_obj_key, cell_query_obj_key]

--- a/matrix/lambdas/daemons/v0/driver.py
+++ b/matrix/lambdas/daemons/v0/driver.py
@@ -10,7 +10,7 @@ from matrix.common.aws.dynamo_handler import DynamoHandler, DynamoTable, Request
 from matrix.common.aws.redshift_handler import RedshiftHandler
 from matrix.common.aws.sqs_handler import SQSHandler
 from matrix.common.aws.s3_handler import S3Handler
-from matrix.common.query_constructor import list_to_query_str
+from matrix.common.query_constructor import format_str_list
 
 logger = Logging.get_logger(__name__)
 
@@ -143,13 +143,13 @@ class Driver:
         exp_query = expression_query_template.format(self.query_results_bucket,
                                                      self.request_id,
                                                      self.redshift_role_arn,
-                                                     list_to_query_str(resolved_bundle_fqids))
+                                                     format_str_list(resolved_bundle_fqids))
         exp_query_obj_key = self.s3_handler.store_content_in_s3(f"{self.request_id}/expression", exp_query)
 
         cell_query = cell_query_template.format(self.query_results_bucket,
                                                 self.request_id,
                                                 self.redshift_role_arn,
-                                                list_to_query_str(resolved_bundle_fqids))
+                                                format_str_list(resolved_bundle_fqids))
         cell_query_obj_key = self.s3_handler.store_content_in_s3(f"{self.request_id}/cell", cell_query)
 
         return [feature_query_obj_key, exp_query_obj_key, cell_query_obj_key]
@@ -165,7 +165,7 @@ class Driver:
 
     def _fetch_bundle_count_from_analysis_table(self, resolved_bundle_fqids: list):
         analysis_table_bundle_count_query = analysis_bundle_count_query_template.format(
-            list_to_query_str(resolved_bundle_fqids))
+            format_str_list(resolved_bundle_fqids))
         analysis_table_bundle_count_query = analysis_table_bundle_count_query.strip().replace('\n', '')
         results = self.redshift_handler.transaction([analysis_table_bundle_count_query],
                                                     read_only=True,

--- a/matrix/lambdas/daemons/v0/driver.py
+++ b/matrix/lambdas/daemons/v0/driver.py
@@ -134,10 +134,6 @@ class Driver:
         lines = data.splitlines()[1:]
         return list(map(_parse_line, lines))
 
-    @staticmethod
-    def _format_bundle_fqids(bundle_fqids: typing.List[str]) -> str:
-        return '(' + ', '.join("'" + str(b) + "'" for b in bundle_fqids) + ')'
-
     def _format_and_store_queries_in_s3(self, resolved_bundle_fqids: list):
         feature_query = feature_query_template.format(self.query_results_bucket,
                                                       self.request_id,
@@ -169,7 +165,7 @@ class Driver:
 
     def _fetch_bundle_count_from_analysis_table(self, resolved_bundle_fqids: list):
         analysis_table_bundle_count_query = analysis_bundle_count_query_template.format(
-            self._format_bundle_fqids(resolved_bundle_fqids))
+            list_to_query_str(resolved_bundle_fqids))
         analysis_table_bundle_count_query = analysis_table_bundle_count_query.strip().replace('\n', '')
         results = self.redshift_handler.transaction([analysis_table_bundle_count_query],
                                                     read_only=True,

--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -16,7 +16,7 @@ from . import validation
 from .wait_for import WaitFor
 from matrix.common.constants import MATRIX_ENV_TO_DSS_ENV, MatrixRequestStatus
 from matrix.common.aws.redshift_handler import RedshiftHandler
-from matrix.common.query_constructor import list_to_query_str
+from matrix.common.query_constructor import format_str_list
 
 
 INPUT_BUNDLE_IDS = {
@@ -206,7 +206,7 @@ class TestMatrixServiceV0(MatrixServiceTest):
         cell_row_count = bundle_data['cell_count']
         expression_row_count = bundle_data['exp_count']
 
-        cellkeys = list_to_query_str(self._get_cellkeys_from_fqid(bundle_fqid))
+        cellkeys = format_str_list(self._get_cellkeys_from_fqid(bundle_fqid))
         self.assertTrue(len(cellkeys) > 0)
 
         try:

--- a/tests/unit/common/test_query_constructor.py
+++ b/tests/unit/common/test_query_constructor.py
@@ -502,18 +502,18 @@ GROUP BY analysis.protocol
         self.assertEqual(query, expected_sql)
 
 
-class TestListToQueryStr(unittest.TestCase):
+class TestFormatStrList(unittest.TestCase):
 
     def test_multiple_values(self):
 
         values = ["id1.version", "id2.version"]
         formatted_values = "('id1.version', 'id2.version')"
 
-        self.assertEqual(query_constructor.list_to_query_str(values), formatted_values)
+        self.assertEqual(query_constructor.format_str_list(values), formatted_values)
 
     def test_single_value(self):
 
         values = ["id1.version"]
         formatted_values = "('id1.version')"
 
-        self.assertEqual(query_constructor.list_to_query_str(values), formatted_values)
+        self.assertEqual(query_constructor.format_str_list(values), formatted_values)

--- a/tests/unit/common/test_query_constructor.py
+++ b/tests/unit/common/test_query_constructor.py
@@ -500,3 +500,20 @@ GROUP BY analysis.protocol
 ;
 """
         self.assertEqual(query, expected_sql)
+
+
+class TestListToQueryStr(unittest.TestCase):
+
+    def test_multiple_values(self):
+
+        values = ["id1.version", "id2.version"]
+        formatted_values = "('id1.version', 'id2.version')"
+
+        self.assertEqual(query_constructor.list_to_query_str(values), formatted_values)
+
+    def test_single_value(self):
+
+        values = ["id1.version"]
+        formatted_values = "('id1.version')"
+
+        self.assertEqual(query_constructor.list_to_query_str(values), formatted_values)

--- a/tests/unit/lambdas/daemons/test_notification.py
+++ b/tests/unit/lambdas/daemons/test_notification.py
@@ -80,5 +80,17 @@ class TestNotificationHandler(unittest.TestCase):
         handler = NotificationHandler(self.bundle_uuid, self.bundle_version, "TOMBSTONE")
         handler.remove_bundle()
 
-        mock_transaction.assert_called_once_with([f"DELETE FROM analysis WHERE bundle_fqid="
-                                                  f"'{self.bundle_uuid}.{self.bundle_version}'"])
+        mock_transaction.assert_called_once_with([
+            NotificationHandler.DELETE_EXPRESSION_QUERY_TEMPLATE.format(
+                bundle_uuid=self.bundle_uuid,
+                bundle_version=self.bundle_version
+            ),
+            NotificationHandler.DELETE_CELL_QUERY_TEMPLATE.format(
+                bundle_uuid=self.bundle_uuid,
+                bundle_version=self.bundle_version
+            ),
+            NotificationHandler.DELETE_ANALYSIS_QUERY_TEMPLATE.format(
+                bundle_uuid=self.bundle_uuid,
+                bundle_version=self.bundle_version
+            )
+        ])

--- a/tests/unit/lambdas/daemons/test_v0_driver.py
+++ b/tests/unit/lambdas/daemons/test_v0_driver.py
@@ -36,19 +36,6 @@ class TestDriver(unittest.TestCase):
                                                                 len(bundle_fqids))
         mock_complete_subtask_execution.assert_called_once_with(Subtask.DRIVER)
 
-    def test_bundle_fqid_format(self):
-
-        two_bundle_fqids = ["id1.version", "id2.version"]
-        formatted_two_bundle_fqids = "('id1.version', 'id2.version')"
-
-        self.assertEqual(self._driver._format_bundle_fqids(two_bundle_fqids), formatted_two_bundle_fqids)
-
-        one_bundle_fqid = ["id1.version"]
-        formatted_one_bundle_fqid = "('id1.version')"
-
-        self.assertEqual(self._driver._format_bundle_fqids(one_bundle_fqid), formatted_one_bundle_fqid)
-
-    @mock.patch("matrix.common.aws.redshift_handler.RedshiftHandler.transaction")
     @mock.patch("matrix.lambdas.daemons.v0.driver.Driver._format_and_store_queries_in_s3")
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.complete_subtask_execution")
     @mock.patch("matrix.common.aws.dynamo_handler.DynamoHandler.set_table_field_with_value")

--- a/tests/unit/lambdas/daemons/test_v0_driver.py
+++ b/tests/unit/lambdas/daemons/test_v0_driver.py
@@ -36,6 +36,7 @@ class TestDriver(unittest.TestCase):
                                                                 len(bundle_fqids))
         mock_complete_subtask_execution.assert_called_once_with(Subtask.DRIVER)
 
+    @mock.patch("matrix.common.aws.redshift_handler.RedshiftHandler.transaction")
     @mock.patch("matrix.lambdas.daemons.v0.driver.Driver._format_and_store_queries_in_s3")
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.complete_subtask_execution")
     @mock.patch("matrix.common.aws.dynamo_handler.DynamoHandler.set_table_field_with_value")


### PR DESCRIPTION
Changes:
- DELETE now deletes all rows in `cell`, `expression` and `analysis` tables associated with the deleted bundle (previously only `analysis`, i.e. the reference to the bundle fqid)
- Updated functional test to verify row counts by cellkey (previously bundle fqid)
- Refactored `Driver._format_bundle_fqids` -> `query_constructor.list_to_query_str`

Manual testing:
- functional tests passing locally