### PR TITLE
return error from post request and driver of v0 if bundle manifest or bundle input is empty

### DIFF
--- a/matrix/lambdas/api/v0/core.py
+++ b/matrix/lambdas/api/v0/core.py
@@ -26,24 +26,24 @@ def post_matrix(body: dict):
     if format not in expected_formats:
         return ({'message': "Invalid parameters supplied. "
                             "Please supply a valid `format`. "
-                            "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                            "Visit https://matrix.data.humancellatlas.org for more information."},
                 requests.codes.bad_request)
     if has_ids and has_url:
         return ({'message': "Invalid parameters supplied. "
                             "Please supply either one of `bundle_fqids` or `bundle_fqids_url`. "
-                            "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                            "Visit https://matrix.data.humancellatlas.org for more information."},
                 requests.codes.bad_request)
 
     if not has_ids and not has_url:
         return ({'message': "Invalid parameters supplied. "
                             "One of `bundle_fqids` or `bundle_fqids_url` must be supplied. "
-                            "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                            "Visit https://matrix.data.humancellatlas.org for more information."},
                 requests.codes.bad_request)
 
     if not has_url and len(json.dumps(body['bundle_fqids'])) > 128000:
         return ({'message': "List of bundle fqids is too large. "
                             "Consider using bundle_fqids_url instead. "
-                            "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                            "Visit https://matrix.data.humancellatlas.org for more information."},
                 requests.codes.request_entity_too_large)
 
     if has_url:
@@ -55,7 +55,7 @@ def post_matrix(body: dict):
         if len(bundle_fqids) == 0:
             return ({'message': "Invalid parameters supplied. "
                                 "Please supply non empty `bundle_fqids`. "
-                                "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                                "Visit https://matrix.data.humancellatlas.org for more information."},
                     requests.codes.bad_request)
 
     request_id = str(uuid.uuid4())

--- a/matrix/lambdas/api/v0/core.py
+++ b/matrix/lambdas/api/v0/core.py
@@ -52,6 +52,11 @@ def post_matrix(body: dict):
     else:
         bundle_fqids = body['bundle_fqids']
         bundle_fqids_url = None
+        if len(bundle_fqids) == 0:
+            return ({'message': "Invalid parameters supplied. "
+                                "Please supply non empty `bundle_fqids`. "
+                                "Visit https://matrix.dev.data.humancellatlas.org for more information."},
+                    requests.codes.bad_request)
 
     request_id = str(uuid.uuid4())
     RequestTracker(request_id).initialize_request(format)

--- a/matrix/lambdas/daemons/v0/driver.py
+++ b/matrix/lambdas/daemons/v0/driver.py
@@ -105,6 +105,11 @@ class Driver:
         if bundle_fqids_url:
             response = self._get_bundle_manifest(bundle_fqids_url)
             resolved_bundle_fqids = self._parse_download_manifest(response.text)
+            if len(resolved_bundle_fqids) == 0:
+                error_msg = "no bundles found in the supplied bundle manifest"
+                logger.info(error_msg)
+                self.request_tracker.log_error(error_msg)
+                return
         else:
             resolved_bundle_fqids = bundle_fqids
         logger.debug(f"resolved bundles: {resolved_bundle_fqids}")

--- a/tests/unit/lambdas/api/test_v0_core.py
+++ b/tests/unit/lambdas/api/test_v0_core.py
@@ -74,6 +74,18 @@ class TestCore(unittest.TestCase):
         self.assertEqual(response[1], requests.codes.bad_request)
 
     @mock.patch("matrix.common.aws.lambda_handler.LambdaHandler.invoke")
+    def test_post_matrix_with_empty_bundle_ids(self, mock_lambda_invoke):
+        bundle_fqids = []
+        format = "loom"
+
+        body = {
+            'bundle_fqids': bundle_fqids,
+            'format': format
+        }
+        response = post_matrix(body)
+        self.assertEqual(response[1], requests.codes.bad_request)
+
+    @mock.patch("matrix.common.aws.lambda_handler.LambdaHandler.invoke")
     def test_post_matrix_with_ids_and_url(self, mock_lambda_invoke):
         bundle_fqids = ["id1", "id2"]
         bundle_fqids_url = "test_url"

--- a/tests/unit/lambdas/daemons/test_v0_driver.py
+++ b/tests/unit/lambdas/daemons/test_v0_driver.py
@@ -97,6 +97,34 @@ class TestDriver(unittest.TestCase):
         error_msg = "resolved bundles in request do not match bundles available in matrix service"
         mock_log_error.assert_called_once_with(error_msg)
 
+    @mock.patch("matrix.common.request.request_tracker.RequestTracker.log_error")
+    @mock.patch("matrix.common.aws.redshift_handler.RedshiftHandler.transaction")
+    @mock.patch("matrix.lambdas.daemons.v0.driver.Driver._format_and_store_queries_in_s3")
+    @mock.patch("matrix.common.request.request_tracker.RequestTracker.complete_subtask_execution")
+    @mock.patch("matrix.common.aws.dynamo_handler.DynamoHandler.set_table_field_with_value")
+    @mock.patch("requests.get")
+    @mock.patch("matrix.lambdas.daemons.v0.driver.Driver._parse_download_manifest")
+    def test_run_with_url_with_empty_bundles(self,
+                                             mock_parse_download_manifest,
+                                             mock_get,
+                                             mock_set_table_field_with_value,
+                                             mock_complete_subtask_execution,
+                                             mock_store_queries_in_s3,
+                                             mock_redshift_transaction,
+                                             mock_log_error):
+        bundle_fqids_url = "test_url"
+        bundle_fqids = []
+        format = "test_format"
+        mock_store_queries_in_s3.return_value = []
+        mock_redshift_transaction.return_value = [[3]]
+
+        mock_parse_download_manifest.return_value = bundle_fqids
+        self._driver.run(None, bundle_fqids_url, format)
+
+        mock_parse_download_manifest.assert_called_once()
+        error_msg = "no bundles found in the supplied bundle manifest"
+        mock_log_error.assert_called_once_with(error_msg)
+
     def test_parse_download_manifest(self):
         test_download_manifest = "UUID\tVERSION\nbundle_id_1\tbundle_version_1\nbundle_id_2\tbundle_version_2"
 


### PR DESCRIPTION
Resolves #327 . Return error from post request and driver of v0 if bundle manifest or bundle input is empty