### PR TITLE
Run loader script in background on EC2

### DIFF
--- a/scripts/redshift/ec2_instance_manager.py
+++ b/scripts/redshift/ec2_instance_manager.py
@@ -82,7 +82,8 @@ class EC2InstanceManager:
                f"ubuntu@{self.name}",
                f"cd /mnt && export DEPLOYMENT_STAGE={self.deployment_stage} && "
                f"export ACCOUNT_ID={self.account_id} && source environment && sudo pip3 install -U setuptools && "
-               f"sudo pip3 install -r requirements.txt && python3 loader.py --max-workers {max_workers} "
+               f"sudo pip3 install -r requirements.txt; "
+               f"nohup python3 loader.py --max-workers {max_workers} "
                f"--state {state} --s3-upload-id {s3_upload_id}"
                + (f" --project-uuids {' '.join(project_uuids)}" if project_uuids else "")
-               + (f" --bundle-uuids {' '.join(bundle_uuids)}" if bundle_uuids else ""))
+               + (f" --bundle-uuids {' '.join(bundle_uuids)}" if bundle_uuids else "") + " &> /mnt/loader.log &")


### PR DESCRIPTION
Before, the remote command would halt if you lost your connection. For
long-running loader jobs, this was a problem. This change runs the
loader script in the background so this doesn't happen, and it writes
stdout/stderr to a log file.