### PR TITLE
remove cell query from sqs on cache hit

### DIFF
--- a/tests/unit/docker/test_query_runner.py
+++ b/tests/unit/docker/test_query_runner.py
@@ -152,13 +152,9 @@ class TestQueryRunner(MatrixTestCaseUsingMockAWS):
         mock_format.return_value = "test_format"
         mock_s3_results_key.return_value = "test_s3_results_key"
         mock_lookup_cached_result.return_value = "test_cached_result_key"
-        # mock_schedule_conversion.return_value = "123-123"
 
-        self.query_runner.run()
+        self.query_runner.run(max_loops=1)
 
-        # mock_schedule_conversion.assert_called_once_with(request_id,
-        #                                                  "test_format",
-        #                                                  "test_s3_results_key")
         mock_copy_obj.assert_called_once_with("test_cached_result_key", "test_s3_results_key")
         mock_is_request_ready_for_conversion.assert_not_called()
         mock_write_batch_job_id_to_db.assert_not_called()

--- a/tests/unit/docker/test_query_runner.py
+++ b/tests/unit/docker/test_query_runner.py
@@ -126,6 +126,7 @@ class TestQueryRunner(MatrixTestCaseUsingMockAWS):
     @mock.patch("matrix.common.aws.batch_handler.BatchHandler.schedule_matrix_conversion")
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.is_request_ready_for_conversion")
     @mock.patch("matrix.common.aws.s3_handler.S3Handler.copy_obj")
+    @mock.patch("matrix.common.aws.sqs_handler.SQSHandler.delete_message_from_queue")
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.s3_results_key", new_callable=mock.PropertyMock)
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.format", new_callable=mock.PropertyMock)
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.write_batch_job_id_to_db")
@@ -139,6 +140,7 @@ class TestQueryRunner(MatrixTestCaseUsingMockAWS):
                                                                    mock_write_batch_job_id_to_db,
                                                                    mock_format,
                                                                    mock_s3_results_key,
+                                                                   mock_delete_message_from_queue,
                                                                    mock_copy_obj,
                                                                    mock_is_request_ready_for_conversion,
                                                                    mock_schedule_matrix_conversion):
@@ -155,6 +157,7 @@ class TestQueryRunner(MatrixTestCaseUsingMockAWS):
 
         self.query_runner.run(max_loops=1)
 
+        mock_delete_message_from_queue.assert_called_once_with("test_query_job_q_name", mock.ANY)
         mock_copy_obj.assert_called_once_with("test_cached_result_key", "test_s3_results_key")
         mock_is_request_ready_for_conversion.assert_not_called()
         mock_write_batch_job_id_to_db.assert_not_called()


### PR DESCRIPTION
Fixes a bug where on cache hit the cell query message was not removed from the SQS queue and was reprocessed resulting in the error message `Specified unload destination on S3 is not empty. Consider using a different bucket / prefix, manually removing the target files in S3, or using the ALLOWOVERWRITE option.` This error was propagated to Dynamo, breaking the GET endpoint a few minutes after the request would complete