### PR TITLE
Create cache invalidation tool

### DIFF
--- a/matrix/common/aws/s3_handler.py
+++ b/matrix/common/aws/s3_handler.py
@@ -38,3 +38,17 @@ class S3Handler:
     def exists(self, key):
         objects = self.ls(key)
         return len(objects) > 0
+
+    def delete_objects(self, keys: list) -> list:
+        """
+        Deletes a list keys from this S3 bucket.
+        :param keys: list of S3 keys to delete
+        :return: List of successfully deleted objects
+        """
+        objects = [{'Key': key} for key in keys]
+
+        response = self.s3_bucket.delete_objects(
+            Delete={'Objects': objects}
+        )
+
+        return response['Deleted'] if 'Deleted' in response else []

--- a/scripts/invalidate_cache_entries.py
+++ b/scripts/invalidate_cache_entries.py
@@ -1,0 +1,74 @@
+import argparse
+import os
+import sys
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from matrix.common.aws.dynamo_handler import DynamoHandler, DynamoTable, DeploymentTableField, RequestTableField
+from matrix.common.aws.s3_handler import S3Handler
+from matrix.common.request.request_tracker import RequestTracker
+
+
+def invalidate_cache_entries(request_ids: list = None,
+                             request_hashes: list = None):
+    """
+    Invalidates a list of request IDs and/or request hashes.
+    Invalidation refers to the invalidation of the request in DynamoDB
+    and the deletion of the associated matrix in S3.
+
+    Invalidated requests will return an `ERROR` state and explanation
+    to the user via the GET endpoint.
+
+    Request hashes are resolved to a list of associated request IDs.
+    :param request_ids: list of request IDs to invalidate
+    :param request_hashes: list of request hashes to invalidate
+    """
+    print(f"Invalidating request IDs: {request_ids}")
+    print(f"Invalidating request hashes: {request_hashes}")
+    deployment_stage = os.environ['DEPLOYMENT_STAGE']
+    dynamo_handler = DynamoHandler()
+    data_version = dynamo_handler.get_table_item(table=DynamoTable.DEPLOYMENT_TABLE,
+                                                 key=deployment_stage)[DeploymentTableField.CURRENT_DATA_VERSION.value]
+    for request_hash in request_hashes:
+        items = dynamo_handler.filter_table_items(table=DynamoTable.REQUEST_TABLE,
+                                                  attrs={
+                                                      RequestTableField.REQUEST_HASH.value: request_hash,
+                                                      RequestTableField.DATA_VERSION.value: data_version
+                                                  })
+        for item in items:
+            request_ids.append(item[RequestTableField.REQUEST_ID.value])
+
+    s3_keys_to_delete = []
+    for request_id in request_ids:
+        print(f"Writing deletion error to {request_id} in DynamoDB.")
+        request_tracker = RequestTracker(request_id=request_id)
+        request_tracker.log_error("This request has been deleted and is no longer available for download. "
+                                  "Please generate a new matrix at POST /v1/matrix.")
+        s3_keys_to_delete.append(request_tracker.s3_results_key)
+
+    print(f"Deleting matrices at the following S3 keys: {s3_keys_to_delete}")
+    s3_results_bucket_handler = S3Handler(os.environ['MATRIX_RESULTS_BUCKET'])
+    deleted_objects = s3_results_bucket_handler.delete_objects(s3_keys_to_delete)
+
+    deleted_keys = [deleted_object['Key'] for deleted_object in deleted_objects]
+
+    print(f"Successfully deleted the following matrices {deleted_keys}. ({len(deleted_keys)}/{len(s3_keys_to_delete)})")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request-ids",
+                        help="List of request IDs to redact.",
+                        nargs="*",
+                        type=str,
+                        default=None)
+    parser.add_argument("--request-hashes",
+                        help="List of request hashes to redact.",
+                        nargs="*",
+                        type=str,
+                        default=None)
+    args = parser.parse_args()
+
+    invalidate_cache_entries(request_ids=args.request_ids,
+                             request_hashes=args.request_hashes)

--- a/tests/unit/common/aws/test_dynamo_handler.py
+++ b/tests/unit/common/aws/test_dynamo_handler.py
@@ -179,3 +179,27 @@ class TestDynamoHandler(MatrixTestCaseUsingMockAWS):
         self.handler.create_request_table_entry(self.request_id, self.format)
         entry = self.handler.get_table_item(DynamoTable.REQUEST_TABLE, key=self.request_id)
         self.assertEqual(entry[RequestTableField.ROW_COUNT.value], 0)
+
+    def test_filter_table_items(self):
+        items = self.handler.filter_table_items(
+            table=DynamoTable.REQUEST_TABLE,
+            attrs={RequestTableField.REQUEST_HASH.value: "N/A"}
+        )
+        self.assertEqual(len(items), 0)
+
+        self.handler.create_request_table_entry(self.request_id, self.format)
+        self.handler.create_request_table_entry(str(uuid.uuid4()), "test_format")
+
+        items = self.handler.filter_table_items(
+            table=DynamoTable.REQUEST_TABLE,
+            attrs={RequestTableField.REQUEST_HASH.value: "N/A"}
+        )
+        self.assertEqual(len(items), 2)
+
+        items = self.handler.filter_table_items(
+            table=DynamoTable.REQUEST_TABLE,
+            attrs={RequestTableField.REQUEST_HASH.value: "N/A",
+                   RequestTableField.FORMAT.value: self.format}
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0][RequestTableField.REQUEST_ID.value], self.request_id)

--- a/tests/unit/common/aws/test_s3_handler.py
+++ b/tests/unit/common/aws/test_s3_handler.py
@@ -65,3 +65,42 @@ class TestS3Handler(MatrixTestCaseUsingMockAWS):
 
         self.s3_handler.store_content_in_s3(obj_key, test_content)
         self.assertTrue(self.s3_handler.exists(obj_key))
+
+    def test_delete_objects(self):
+        obj_key_1 = "test_key_1"
+        obj_key_2 = "test_key_2"
+        obj_key_3 = "test_key_3"
+        test_content = "test_content"
+
+        self.s3_handler.store_content_in_s3(obj_key_1, test_content)
+        self.s3_handler.store_content_in_s3(obj_key_2, test_content)
+        self.s3_handler.store_content_in_s3(obj_key_3, test_content)
+
+        expected_keys = [obj_key_1, obj_key_2, obj_key_3]
+        keys_in_s3 = [s3_obj['Key'] for s3_obj in self.s3_handler.ls("")]
+        self.assertEqual(keys_in_s3, expected_keys)
+
+        with self.subTest("Delete no objects"):
+            deleted_objects = self.s3_handler.delete_objects(keys=[])
+
+            expected_keys = [obj_key_1, obj_key_2, obj_key_3]
+            keys_in_s3 = [s3_obj['Key'] for s3_obj in self.s3_handler.ls("")]
+            self.assertEqual(keys_in_s3, expected_keys)
+            self.assertTrue(len(deleted_objects) == 0)
+
+        with self.subTest("Delete one object"):
+            deleted_objects = self.s3_handler.delete_objects(keys=[obj_key_1])
+
+            expected_keys = [obj_key_2, obj_key_3]
+            keys_in_s3 = [s3_obj['Key'] for s3_obj in self.s3_handler.ls("")]
+            self.assertEqual(keys_in_s3, expected_keys)
+            self.assertEqual(deleted_objects[0]['Key'], obj_key_1)
+
+        with self.subTest("Delete multiple objects"):
+            deleted_objects = self.s3_handler.delete_objects(keys=[obj_key_2, obj_key_3])
+
+            expected_keys = []
+            keys_in_s3 = [s3_obj['Key'] for s3_obj in self.s3_handler.ls("")]
+            self.assertEqual(keys_in_s3, expected_keys)
+            self.assertEqual(deleted_objects[0]['Key'], obj_key_2)
+            self.assertEqual(deleted_objects[1]['Key'], obj_key_3)

--- a/tests/unit/scripts/test_invalidate_cache_entries.py
+++ b/tests/unit/scripts/test_invalidate_cache_entries.py
@@ -1,0 +1,93 @@
+import os
+import mock
+
+from matrix.common.aws.dynamo_handler import DynamoHandler, DynamoTable, RequestTableField
+from matrix.common.aws.s3_handler import S3Handler
+from scripts.invalidate_cache_entries import invalidate_cache_entries
+from tests.unit import MatrixTestCaseUsingMockAWS
+
+
+class TestInvalidateCacheEntries(MatrixTestCaseUsingMockAWS):
+    def setUp(self):
+        super(TestInvalidateCacheEntries, self).setUp()
+
+        self.create_test_deployment_table()
+        self.create_test_request_table()
+
+        self.init_test_deployment_table()
+        self.create_s3_results_bucket()
+
+        self.dynamo_handler = DynamoHandler()
+        self.deployment_stage = os.environ['DEPLOYMENT_STAGE']
+
+    @mock.patch("matrix.common.aws.cloudwatch_handler.CloudwatchHandler.put_metric_data")
+    def test_invalidate_cache_entries(self, mock_put_metric_data):
+        request_hash_1 = "test_hash_1"
+        request_hash_2 = "test_hash_2"
+        request_id_1 = "test_id_1"
+        request_id_2 = "test_id_2"
+        request_id_3 = "test_id_3"
+        request_id_4 = "test_id_4"
+        test_format = "test_format"
+        test_content = "test_content"
+
+        s3_key_1 = f"0/{request_hash_1}/{request_id_1}.{test_format}"
+        s3_key_2 = f"0/{request_hash_1}/{request_id_2}.{test_format}"
+        s3_key_3 = f"0/{request_hash_2}/{request_id_3}.{test_format}"
+        s3_key_4 = f"0/{request_hash_2}/{request_id_4}.{test_format}"
+
+        dynamo_handler = DynamoHandler()
+        dynamo_handler.create_request_table_entry(request_id_1, test_format)
+        dynamo_handler.create_request_table_entry(request_id_2, test_format)
+        dynamo_handler.create_request_table_entry(request_id_3, test_format)
+        dynamo_handler.create_request_table_entry(request_id_4, test_format)
+
+        dynamo_handler.set_table_field_with_value(table=DynamoTable.REQUEST_TABLE,
+                                                  key=request_id_1,
+                                                  field_enum=RequestTableField.REQUEST_HASH,
+                                                  field_value=request_hash_1)
+        dynamo_handler.set_table_field_with_value(table=DynamoTable.REQUEST_TABLE,
+                                                  key=request_id_2,
+                                                  field_enum=RequestTableField.REQUEST_HASH,
+                                                  field_value=request_hash_1)
+        dynamo_handler.set_table_field_with_value(table=DynamoTable.REQUEST_TABLE,
+                                                  key=request_id_3,
+                                                  field_enum=RequestTableField.REQUEST_HASH,
+                                                  field_value=request_hash_2)
+        dynamo_handler.set_table_field_with_value(table=DynamoTable.REQUEST_TABLE,
+                                                  key=request_id_4,
+                                                  field_enum=RequestTableField.REQUEST_HASH,
+                                                  field_value=request_hash_2)
+
+        s3_results_bucket_handler = S3Handler(os.environ['MATRIX_RESULTS_BUCKET'])
+        s3_results_bucket_handler.store_content_in_s3(s3_key_1, test_content)
+        s3_results_bucket_handler.store_content_in_s3(s3_key_2, test_content)
+        s3_results_bucket_handler.store_content_in_s3(s3_key_3, test_content)
+        s3_results_bucket_handler.store_content_in_s3(s3_key_4, test_content)
+
+        self.assertTrue(s3_results_bucket_handler.exists(s3_key_1))
+        self.assertTrue(s3_results_bucket_handler.exists(s3_key_2))
+        self.assertTrue(s3_results_bucket_handler.exists(s3_key_3))
+        self.assertTrue(s3_results_bucket_handler.exists(s3_key_4))
+
+        invalidate_cache_entries(request_ids=[request_id_3],
+                                 request_hashes=[request_hash_1])
+
+        error_1 = dynamo_handler.get_table_item(table=DynamoTable.REQUEST_TABLE,
+                                                key=request_id_1)[RequestTableField.ERROR_MESSAGE.value]
+        error_2 = dynamo_handler.get_table_item(table=DynamoTable.REQUEST_TABLE,
+                                                key=request_id_2)[RequestTableField.ERROR_MESSAGE.value]
+        error_3 = dynamo_handler.get_table_item(table=DynamoTable.REQUEST_TABLE,
+                                                key=request_id_3)[RequestTableField.ERROR_MESSAGE.value]
+        error_4 = dynamo_handler.get_table_item(table=DynamoTable.REQUEST_TABLE,
+                                                key=request_id_4)[RequestTableField.ERROR_MESSAGE.value]
+
+        self.assertFalse(s3_results_bucket_handler.exists(s3_key_1))
+        self.assertFalse(s3_results_bucket_handler.exists(s3_key_2))
+        self.assertFalse(s3_results_bucket_handler.exists(s3_key_3))
+        self.assertTrue(s3_results_bucket_handler.exists(s3_key_4))
+
+        self.assertNotEqual(error_1, 0)
+        self.assertNotEqual(error_2, 0)
+        self.assertNotEqual(error_3, 0)
+        self.assertEqual(error_4, 0)


### PR DESCRIPTION
This tool invalidates a list of request IDs and/or request hashes (hashes are resolved to all associated request IDs). For every request ID, a user-friendly error will be written to its DynamoDB row which will propagate to the user via the GET endpoint. Additionally, the associated matrices will be deleted from S3.

Usage:
`python3 scripts/invalidate_cache_entries.py --request-ids [REQUEST_IDS] --request-hashes [REQUEST_HASHES]`