### PR TITLE
re-enable DSS subscription in non prod envs

### DIFF
--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -3,6 +3,7 @@ botocore==1.12.145
 connexion[swagger-ui]==2.2.0
 inflection==0.3.1
 itsdangerous==0.24
+requests-http-signature==0.1.0
 MarkupSafe==1.0
 PyYAML==4.2b1
 requests==2.20.0

--- a/config/matrix-api.yml
+++ b/config/matrix-api.yml
@@ -88,26 +88,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v0_MatrixFormat'
-  /v0/dss/notification:
-    post:
-      summary: "Handles a DSS notification event."
-      description: "Handles a DSS notification event such as bundle CREATE, DELETE and TOMBSTONE."
-      operationId: matrix.lambdas.api.v0.core.dss_notification
-      tags:
-        - internal
-      requestBody:
-        description: "DSS subscription event JSON payload"
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/v0_DssNotification'
-      responses:
-        "200":
-          description: "Success"
-          content:
-            application/json:
-              schema:
-                type: string
   /v1/matrix:
     post:
       summary: Request an expression matrix
@@ -433,22 +413,6 @@ components:
       properties:
         message:
           type: string
-    v0_DssNotification:
-      type: object
-      properties:
-        transaction_id:
-          type: string
-        subscription_id:
-          type: string
-        event_type:
-          type: string
-        match:
-          type: object
-          properties:
-            bundle_uuid:
-              type: string
-            bundle_version:
-              type: string
     v1_ComparisonFilterOperator:
       description: 'Comparison operators allowed in matrix filters.'
       type: string

--- a/matrix/lambdas/api/v0/core.py
+++ b/matrix/lambdas/api/v0/core.py
@@ -163,22 +163,3 @@ def get_matrix(request_id: str):
 def get_formats():
     return ([item.value for item in MatrixFormat],
             requests.codes.ok)
-
-
-def dss_notification(body):
-    bundle_uuid = body['match']['bundle_uuid']
-    bundle_version = body['match']['bundle_version']
-    subscription_id = body['subscription_id']
-    event_type = body['event_type']
-
-    payload = {
-        'bundle_uuid': bundle_uuid,
-        'bundle_version': bundle_version,
-        'event_type': event_type,
-    }
-    queue_url = matrix_infra_config.notification_q_url
-    sqs_handler.add_message_to_queue(queue_url, payload)
-
-    return (f"Received notification from subscription {subscription_id}: "
-            f"{event_type} {bundle_uuid}.{bundle_version}",
-            requests.codes.ok)

--- a/matrix/lambdas/api/v1/core.py
+++ b/matrix/lambdas/api/v1/core.py
@@ -3,7 +3,6 @@ import os
 import requests
 import uuid
 
-from connexion.lifecycle import ConnexionResponse
 
 from matrix.common import constants
 from matrix.common import query_constructor
@@ -13,10 +12,8 @@ from matrix.common.config import MatrixInfraConfig
 from matrix.common.aws.lambda_handler import LambdaHandler, LambdaName
 from matrix.common.aws.redshift_handler import RedshiftHandler, TableName
 from matrix.common.request.request_tracker import RequestTracker
-from matrix.common.aws.sqs_handler import SQSHandler
 
 lambda_handler = LambdaHandler()
-sqs_handler = SQSHandler()
 matrix_infra_config = MatrixInfraConfig()
 
 
@@ -267,22 +264,3 @@ def get_feature_detail(feature_name: str):
     else:
         return ({"message": f"Feature {feature_name} not found."},
                 requests.codes.not_found)
-
-
-def dss_notification(body):
-    bundle_uuid = body['match']['bundle_uuid']
-    bundle_version = body['match']['bundle_version']
-    subscription_id = body['subscription_id']
-    event_type = body['event_type']
-
-    payload = {
-        'bundle_uuid': bundle_uuid,
-        'bundle_version': bundle_version,
-        'event_type': event_type,
-    }
-    queue_url = matrix_infra_config.notification_q_url
-    sqs_handler.add_message_to_queue(queue_url, payload)
-
-    return ConnexionResponse(status_code=requests.codes.ok,
-                             body=f"Received notification from subscription {subscription_id}: "
-                                  f"{event_type} {bundle_uuid}.{bundle_version}")

--- a/matrix/lambdas/daemons/notification.py
+++ b/matrix/lambdas/daemons/notification.py
@@ -58,7 +58,7 @@ class NotificationHandler:
         content_type_patterns = ['application/json; dcp-type="metadata*"']
         filename_patterns = ["*zarr*",  # match expression data
                              "*.results",  # match SS2 results files
-                             "*.mtx", "genes.tsv", "barcodes.tsv"]  # match 10X results files
+                             "*.mtx", "genes.tsv", "barcodes.tsv", "empty_drops_result.csv"]  # match 10X results files
 
         # clean up working directory in case of Lambda container reuse
         shutil.rmtree(f"{staging_dir}/{MetadataToPsvTransformer.OUTPUT_DIRNAME}", ignore_errors=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ domovoi == 1.5.7
 flake8==3.7.8
 locustio==0.9.0
 matplotlib==3.0.2
-moto==1.3.8
+moto==1.3.13
 pytest==3.8.2
 python-dateutil==2.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ botocore==1.12.145
 connexion[swagger-ui]==2.2.0
 dcplib==2.1.0
 hca==6.3.0
+requests-http-signature==0.1.0
 inflection==0.3.1
 itsdangerous==0.24
 loompy==2.0.15

--- a/scripts/dss_subscription.py
+++ b/scripts/dss_subscription.py
@@ -1,81 +1,126 @@
 import base64
 import json
 import os
-import requests
+import secrets
+import sys
+import traceback
 
+import boto3
 import hca
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
 from matrix.common.config import MatrixInfraConfig
+from matrix.common.constants import SUPPORTED_METADATA_SCHEMA_VERSIONS, MetadataSchemaName
 
 
-# DSSClient functions are generated at runtime and are difficult to mock
-def get_subscriptions(dss_client: hca.dss.DSSClient,
-                      replica: str,
-                      subscription_type: str):  # pragma: no cover
-    return dss_client.get_subscriptions(replica=replica,
-                                        subscription_type=subscription_type)['subscriptions']
-
-
-def delete_subscription(dss_client: hca.dss.DSSClient,
-                        replica: str,
-                        subscription_type: str,
-                        uuid: str):  # pragma: no cover
-    return dss_client.delete_subscription(replica=replica,
-                                          subscription_type=subscription_type,
-                                          uuid=uuid)
-
-
-def put_subscription(dss_client: hca.dss.DSSClient,
-                     callback_url: str,
-                     jmespath_query: str,
-                     replica: str):  # pragma: no cover
-    return dss_client.put_subscription(callback_url=callback_url,
-                                       jmespath_query=jmespath_query,
-                                       replica=replica)
+DSS_SUBSCRIPTION_HMAC_SECRET_ID = "dss_subscription_hmac_secret_key"
 
 
 def retrieve_gcp_credentials():  # pragma: no cover
     return json.loads(base64.b64decode(MatrixInfraConfig().gcp_service_acct_creds).decode())
 
 
+def _generate_metadata_schema_version_clause(schema: MetadataSchemaName):
+    supported_versions = SUPPORTED_METADATA_SCHEMA_VERSIONS[schema]
+    min_major_case = (
+        f"(files.{schema.value}_json[].provenance.schema_major_version==`{supported_versions['min_major']}` && "
+        f"files.{schema.value}_json[].provenance.schema_minor_version>=`{supported_versions['min_minor']}`)"
+    )
+
+    max_major_case = (
+        f"(files.{schema.value}_json[].provenance.schema_major_version==`{supported_versions['max_major']}` && "
+        f"files.{schema.value}_json[].provenance.schema_minor_version<=`{supported_versions['max_minor']}`)"
+    )
+
+    in_between_case = (
+        f"(files.{schema.value}_json[].provenance.schema_major_version<`{supported_versions['max_major']}` && "
+        f"files.{schema.value}_json[].provenance.schema_major_version>`{supported_versions['min_major']}`)"
+    )
+
+    null_case = f"(files.{schema.value}_json[].provenance.schema_major_version==`null`)"
+
+    return f"({min_major_case} || {max_major_case} || {in_between_case} || {null_case})"
+
+
+def _regenerate_and_set_hmac_secret_key():
+    """
+    Generates and stores in AWS SecretsManager an HMAC secret key used
+    to sign and verify DSS notification events.
+    :return: str Generated HMAC secret key.
+    """
+    secrets_client = boto3.client("secretsmanager", region_name=os.environ['AWS_DEFAULT_REGION'])
+
+    deployment_stage = os.environ['DEPLOYMENT_STAGE']
+    secret_id = f"dcp/matrix/{deployment_stage}/infra"
+    # generate new key
+    hmac_secret_key = secrets.token_hex(16)
+
+    # set key
+    secret = secrets_client.get_secret_value(SecretId=secret_id)
+    blob = json.loads(secret['SecretString'])
+    blob[DSS_SUBSCRIPTION_HMAC_SECRET_ID] = hmac_secret_key
+    secrets_client.put_secret_value(SecretId=secret_id,
+                                    SecretString=json.dumps(blob))
+
+    return hmac_secret_key
+
+
 def recreate_dss_subscription():
+    deployment_stage = os.environ['DEPLOYMENT_STAGE']
+    if deployment_stage == "prod":
+        print("Quitting... DSS Subscriptions are not enabled in prod.")
+        return
+
     gcp_service_acct_creds = retrieve_gcp_credentials()
     with open('gcp_creds.json', 'w') as outfile:
         json.dump(gcp_service_acct_creds, outfile)
+
     try:
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.getcwd() + "/gcp_creds.json"
-        deployment_stage = os.environ['DEPLOYMENT_STAGE']
         replica = "aws"
-        jmespath_query = "(event_type==`CREATE` || event_type==`TOMBSTONE` || event_type==`DELETE`) \
-            && (files.library_preparation_protocol[].library_construction_method.ontology==`EFO:0008931` \
-            || files.library_preparation_protocol[].library_construction_method.ontology_label==`10X v2 sequencing`) \
-            && files.analysis_process[].type.text==`analysis`"
+        # In order to enable DCP integration tests, only subscribe to test bundles
+        jmespath_query = (
+            f"(event_type==`CREATE`)"
+            f" && (files.analysis_process_json[0].type.text==`analysis`)"
+            f" && (files.project_json[].project_core.project_short_name | starts_with(@[0], `{deployment_stage}/`))"
+            f" && (files.library_preparation_protocol_json[0].library_construction_method.ontology==`EFO:0008931`"
+            f" || files.library_preparation_protocol_json[0].library_construction_method.ontology==`EFO:0009310`)"
+        )
+
+        # Schema versions are not enforced while subscriptions only apply to test bundles
+        # for schema in SUPPORTED_METADATA_SCHEMA_VERSIONS:
+        #     jmespath_query += f" && {_generate_metadata_schema_version_clause(schema)}"
 
         if deployment_stage == "prod":
             swagger_url = "https://dss.data.humancellatlas.org/v1/swagger.json"
-            matrix_callback = "https://matrix.data.humancellatlas.org/v0/dss/notifications"
+            matrix_callback = "https://matrix.data.humancellatlas.org/dss/notification"
         else:
             swagger_url = f"https://dss.{deployment_stage}.data.humancellatlas.org/v1/swagger.json"
-            matrix_callback = f"https://matrix.{deployment_stage}.data.humancellatlas.org/v0/dss/notifications"
+            matrix_callback = f"https://matrix.{deployment_stage}.data.humancellatlas.org/dss/notification"
 
         dss_client = hca.dss.DSSClient(swagger_url=swagger_url)
 
-        for subscription in get_subscriptions(dss_client=dss_client, replica=replica, subscription_type="jmespath"):
+        hmac_secret_key = _regenerate_and_set_hmac_secret_key()
+
+        for subscription in dss_client.get_subscriptions(replica=replica, subscription_type="jmespath")['subscriptions']:
             if matrix_callback == subscription["callback_url"]:
-                res = delete_subscription(dss_client=dss_client,
-                                          replica=replica,
-                                          subscription_type="jmespath",
-                                          uuid=subscription["uuid"])
+                res = dss_client.delete_subscription(replica=replica,
+                                                     subscription_type="jmespath",
+                                                     uuid=subscription["uuid"])
                 print("Deleted subscription {}: {}".format(subscription["uuid"], res))
 
-        print("Not resubscribing to dss for the time being.")
-        # resp = put_subscription(dss_client=dss_client,
-        #                         callback_url=matrix_callback,
-        #                         jmespath_query=jmespath_query,
-        #                         replica="aws")
-        # print("Created subscription {}: {}".format(resp["uuid"], resp))
+        resp = dss_client.put_subscription(callback_url=matrix_callback,
+                                           jmespath_query=jmespath_query,
+                                           replica="aws",
+                                           hmac_key_id=DSS_SUBSCRIPTION_HMAC_SECRET_ID,
+                                           hmac_secret_key=hmac_secret_key)
+        print("Created subscription {}: {}".format(resp["uuid"], resp))
 
     except Exception as e:
         print(e)
+        traceback.print_exc()
     os.remove(os.getcwd() + "/gcp_creds.json")
     print("deleted creds file")
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 import boto3
-from moto import mock_dynamodb2, mock_s3, mock_sqs, mock_sts
+from moto import mock_dynamodb2, mock_s3, mock_sqs, mock_sts, mock_secretsmanager
 
 os.environ['DEPLOYMENT_STAGE'] = "test_deployment_stage"
 os.environ['AWS_DEFAULT_REGION'] = "us-east-1"
@@ -44,6 +44,8 @@ class MatrixTestCaseUsingMockAWS(unittest.TestCase):
         self.dynamo_mock.start()
         self.s3_mock = mock_s3()
         self.s3_mock.start()
+        self.secrets_mock = mock_secretsmanager()
+        self.secrets_mock.start()
         self.sqs_mock = mock_sqs()
         self.sqs_mock.start()
         self.sts_mock = mock_sts()

--- a/tests/unit/lambdas/api/test_v0_core.py
+++ b/tests/unit/lambdas/api/test_v0_core.py
@@ -10,7 +10,7 @@ from matrix.common.exceptions import MatrixException
 from matrix.common.aws.dynamo_handler import RequestTableField
 from matrix.common.aws.lambda_handler import LambdaName
 from matrix.common.aws.cloudwatch_handler import MetricName
-from matrix.lambdas.api.v0.core import matrix_infra_config, post_matrix, get_matrix, get_formats, dss_notification
+from matrix.lambdas.api.v0.core import post_matrix, get_matrix, get_formats
 
 
 class TestCore(unittest.TestCase):
@@ -223,28 +223,6 @@ class TestCore(unittest.TestCase):
     def test_get_formats(self):
         response = get_formats()
         self.assertEqual(response[0], [item.value for item in MatrixFormat])
-
-    @mock.patch("matrix.common.aws.sqs_handler.SQSHandler.add_message_to_queue")
-    def test_dss_notification(self, mock_sqs_add):
-        matrix_infra_config.set({'notification_q_url': "notification_q_url"})
-        body = {
-            'subscription_id': "test_sub_id",
-            'event_type': "test_event",
-            'match': {
-                'bundle_uuid': "test_id",
-                'bundle_version': "test_version"
-            }
-        }
-        expected_payload = {
-            'bundle_uuid': "test_id",
-            'bundle_version': "test_version",
-            'event_type': 'test_event'
-        }
-
-        resp = dss_notification(body)
-        mock_sqs_add.assert_called_once_with("notification_q_url", expected_payload)
-
-        self.assertEqual(resp[1], requests.codes.ok)
 
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.is_expired",
                 new_callable=mock.PropertyMock)

--- a/tests/unit/lambdas/api/test_v1_core.py
+++ b/tests/unit/lambdas/api/test_v1_core.py
@@ -220,28 +220,6 @@ class TestCore(unittest.TestCase):
         response = core.get_formats()
         self.assertEqual(response[0], [item.value for item in MatrixFormat])
 
-    @mock.patch("matrix.common.aws.sqs_handler.SQSHandler.add_message_to_queue")
-    def test_dss_notification(self, mock_sqs_add):
-        core.matrix_infra_config.set({'notification_q_url': "notification_q_url"})
-        body = {
-            'subscription_id': "test_sub_id",
-            'event_type': "test_event",
-            'match': {
-                'bundle_uuid': "test_id",
-                'bundle_version': "test_version"
-            }
-        }
-        expected_payload = {
-            'bundle_uuid': "test_id",
-            'bundle_version': "test_version",
-            'event_type': 'test_event'
-        }
-
-        resp = core.dss_notification(body)
-        mock_sqs_add.assert_called_once_with("notification_q_url", expected_payload)
-
-        self.assertEqual(resp.status_code, requests.codes.ok)
-
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.is_expired",
                 new_callable=mock.PropertyMock)
     @mock.patch("matrix.common.aws.dynamo_handler.DynamoHandler.get_table_item")

--- a/tests/unit/scripts/test_dss_subscription.py
+++ b/tests/unit/scripts/test_dss_subscription.py
@@ -1,13 +1,24 @@
+import json
 import mock
 import os
-import unittest
 
-from scripts.dss_subscription import recreate_dss_subscription
+import boto3
+
+from matrix.common import constants
+from matrix.common.etl import get_dss_client
+from scripts.dss_subscription import (recreate_dss_subscription,
+                                      _generate_metadata_schema_version_clause,
+                                      _regenerate_and_set_hmac_secret_key,
+                                      DSS_SUBSCRIPTION_HMAC_SECRET_ID)
+from tests.unit import MatrixTestCaseUsingMockAWS
 
 
-class TestDssSubscription(unittest.TestCase):
+DSS_CLIENT = get_dss_client("dev")
 
+
+class TestDssSubscription(MatrixTestCaseUsingMockAWS):
     def setUp(self):
+        super(TestDssSubscription, self).setUp()
         self.swagger_spec_stub = {
             'info': {
                 'description': "test_description"
@@ -17,35 +28,85 @@ class TestDssSubscription(unittest.TestCase):
             'paths': {}
         }
 
-    @mock.patch("scripts.dss_subscription.put_subscription")
-    @mock.patch("scripts.dss_subscription.delete_subscription")
-    @mock.patch("scripts.dss_subscription.get_subscriptions")
+    @mock.patch("secrets.token_hex")
+    def test_regenerate_and_set_hmac_secret(self, mock_token_hex):
+        secret_name = f"dcp/matrix/{os.environ['DEPLOYMENT_STAGE']}/infra"
+        test_hmac_secret_key = "test_hmac_secret_key"
+        mock_token_hex.return_value = test_hmac_secret_key
+        test_secret = {
+            DSS_SUBSCRIPTION_HMAC_SECRET_ID: test_hmac_secret_key
+        }
+
+        secrets_client = boto3.client("secretsmanager", region_name=os.environ['AWS_DEFAULT_REGION'])
+        secrets_client.create_secret(Name=secret_name,
+                                     SecretString="{}")
+
+        _regenerate_and_set_hmac_secret_key()
+
+        secret = secrets_client.get_secret_value(SecretId=secret_name)
+        decoded = json.loads(secret['SecretString'])
+        self.assertEqual(decoded, test_secret)
+
+    @mock.patch("hca.dss.DSSClient.put_subscription")
+    @mock.patch("hca.dss.DSSClient.delete_subscription")
+    @mock.patch("hca.dss.DSSClient.get_subscriptions")
+    @mock.patch("scripts.dss_subscription._regenerate_and_set_hmac_secret_key")
+    @mock.patch("scripts.dss_subscription._generate_metadata_schema_version_clause")
     @mock.patch("hca.dss.DSSClient.swagger_spec", new_callable=mock.PropertyMock)
     @mock.patch("scripts.dss_subscription.retrieve_gcp_credentials")
     def test_recreate_dss_subscription(self,
                                        mock_retrieve_gcp_credentials,
                                        mock_swagger_spec,
+                                       mock_generate_metadata_schema_version_clause,
+                                       mock_regenerate_and_set_hmac_secret_key,
                                        mock_get_subscriptions,
                                        mock_delete_subscription,
                                        mock_put_subscription):
-        callback = f"https://matrix.{os.environ['DEPLOYMENT_STAGE']}.data.humancellatlas.org/v0/dss/notifications"
+        callback = f"https://matrix.{os.environ['DEPLOYMENT_STAGE']}.data.humancellatlas.org/dss/notification"
         mock_retrieve_gcp_credentials.return_value = {}
         mock_swagger_spec.return_value = self.swagger_spec_stub
-        mock_get_subscriptions.return_value = [{'uuid': "test_uuid", 'callback_url': callback}]
+        mock_get_subscriptions.return_value = {'subscriptions': [{'uuid': "test_uuid", 'callback_url': callback}]}
+        mock_regenerate_and_set_hmac_secret_key.return_value = "test_hmac_secret_key"
 
         recreate_dss_subscription()
 
-        mock_get_subscriptions.assert_called_once_with(dss_client=mock.ANY,
-                                                       replica="aws",
+        mock_get_subscriptions.assert_called_once_with(replica="aws",
                                                        subscription_type="jmespath")
-        mock_delete_subscription.assert_called_once_with(dss_client=mock.ANY,
-                                                         replica="aws",
+        mock_delete_subscription.assert_called_once_with(replica="aws",
                                                          subscription_type="jmespath",
                                                          uuid="test_uuid")
-        # mock_put_subscription.assert_called_once_with(dss_client=mock.ANY,
-        #                                               callback_url=callback,
-        #                                               jmespath_query=mock.ANY,
-        #                                               replica="aws")
+        mock_put_subscription.assert_called_once_with(callback_url=callback,
+                                                      jmespath_query=mock.ANY,
+                                                      replica="aws",
+                                                      hmac_key_id=DSS_SUBSCRIPTION_HMAC_SECRET_ID,
+                                                      hmac_secret_key="test_hmac_secret_key")
+        # self.assertEqual(mock_generate_metadata_schema_version_clause.call_count,
+        #                  len(constants.SUPPORTED_METADATA_SCHEMA_VERSIONS))
+
+    def test_generate_metadata_schema_version_clause(self):
+        project_md_schema_versions = constants.SUPPORTED_METADATA_SCHEMA_VERSIONS[constants.MetadataSchemaName.PROJECT]
+        constants.SUPPORTED_METADATA_SCHEMA_VERSIONS[constants.MetadataSchemaName.PROJECT] = {
+            'max_major': 56,
+            'max_minor': 78,
+            'min_major': 12,
+            'min_minor': 34
+        }
+
+        metadata_schema_version_clause = _generate_metadata_schema_version_clause(constants.MetadataSchemaName.PROJECT)
+
+        expected = (
+            "((files.project_json[].provenance.schema_major_version==`12` && "
+            "files.project_json[].provenance.schema_minor_version>=`34`) || "
+            "(files.project_json[].provenance.schema_major_version==`56` && "
+            "files.project_json[].provenance.schema_minor_version<=`78`) || "
+            "(files.project_json[].provenance.schema_major_version<`56` && "
+            "files.project_json[].provenance.schema_major_version>`12`) || "
+            "(files.project_json[].provenance.schema_major_version==`null`))"
+        )
+
+        print(metadata_schema_version_clause)
+        self.assertEqual(metadata_schema_version_clause, expected)
+        constants.SUPPORTED_METADATA_SCHEMA_VERSIONS[constants.MetadataSchemaName.PROJECT] = project_md_schema_versions
 
     class MatrixInfraConfigStub:
         def __init__(self):


### PR DESCRIPTION
On service deployment, `dev`, `integration` and `staging` environments will recreate a DSS subscription for test bundles only. This change is to re-enable the matrix service in DCP wide integration tests and does not enable the matrix service to respond to AUDR updates. A number of updates to the DSS subscription are included with its reintroduction:

- implement HMAC auth
    - the HMAC secret key is regenerated on every deployment and is stored in AWS SecretsManager
- update JMESPath query
    - subscribes only to test bundles, updated SS2 and 10x filters to select via `library_construction_method.ontology`
    - metadata schema version logic added but unused. This is a decision to enable MS to test against the latest metadata schema versions during DCP wide integration tests.
- moved notification endpoint from `/v0/dss/notification` to `/dss/notification` (removed from Swagger)

Closes #372 