### PR TITLE
Increase connection timeout on chalice deploy

### DIFF
--- a/chalice/Makefile
+++ b/chalice/Makefile
@@ -34,4 +34,4 @@ deploy: clean build
 	@echo -e "########## Deploying to $(DEPLOYMENT_STAGE) environment"
 	@echo -e "#########################################################\n"
 	./build_deploy_config.sh $(DEPLOYMENT_STAGE)
-	chalice deploy --no-autogen-policy --stage $(DEPLOYMENT_STAGE) --api-gateway-stage $(DEPLOYMENT_STAGE)
+	chalice deploy --no-autogen-policy --stage $(DEPLOYMENT_STAGE) --api-gateway-stage $(DEPLOYMENT_STAGE) --connection-timeout 240


### PR DESCRIPTION
The deployment package has gotten kind of big, and it can frequently
time out on even reasonably fast connections. This gives it a few more
minutes.