### PR TITLE
Update integration bundles

### DIFF
--- a/tests/functional/test_matrix_service.py
+++ b/tests/functional/test_matrix_service.py
@@ -25,11 +25,11 @@ from scripts.dss_subscription import DSS_SUBSCRIPTION_HMAC_SECRET_ID
 
 INPUT_BUNDLE_IDS = {
     "integration": [
-        "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z",
-        "ff7ef351-f46f-4c39-b4c3-c8b33423a4c9.2019-02-11T124842.494942Z",
-        "aa8262c2-7a0e-49fd-bac1-d41a4019bd87.2019-02-10T234926.510991Z",
-        "0ef88e4a-a779-4588-8677-953d65ca6d9a.2019-02-10T124405.139571Z",
-        "c881020e-9f53-4f7e-9c49-d9dbd9e8f280.2019-02-09T124912.755814Z",
+        "93cb1d90-10f3-4b76-aa6a-a85450a83968.2019-11-06T140752.790454Z",
+        "626d3e17-6a62-4fe7-838a-323f2cec450a.2019-11-06T140922.234528Z",
+        "4602ed62-8dc1-4b67-a50d-35c3ab34b787.2019-11-06T141032.303970Z",
+        "ce51949d-ca8f-4194-8f96-e470dd749dfa.2019-11-06T143122.339686Z",
+        "635b4815-0cba-4285-b66d-e88b97bf3f20.2019-11-06T141546.990073Z"
     ],
     "staging": [
         "d30147bb-5fa2-4444-ad62-398308e4f8d3.2019-07-18T051541.009170Z",
@@ -49,7 +49,7 @@ INPUT_BUNDLE_IDS = {
 
 NOTIFICATION_TEST_DATA = {
     "integration": {
-        'bundle_fqid': "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z",
+        'bundle_fqid': "ce51949d-ca8f-4194-8f96-e470dd749dfa.2019-11-06T143122.339686Z",
         'cell_count': 1,
         'exp_count': 21876
     },

--- a/tests/functional/transformers/__init__.py
+++ b/tests/functional/transformers/__init__.py
@@ -5,10 +5,10 @@ from matrix.common.constants import BundleType
 ETL_TEST_BUNDLES = {
     'integration': {
         BundleType.SS2: {
-            '5cb665f4-97bb-4176-8ec2-1b83b95c1bc0': {
+            'ce51949d-ca8f-4194-8f96-e470dd749dfa': {
                 TableName.ANALYSIS: "5f7dee36-68e8-41c8-9e5f-50f3c772176a|"
-                                    "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0.2019-02-11T171739.925160Z|"
-                                    "5cb665f4-97bb-4176-8ec2-1b83b95c1bc0|2019-02-11T171739.925160Z|"
+                                    "ce51949d-ca8f-4194-8f96-e470dd749dfa.2019-11-06T143122.339686Z|"
+                                    "ce51949d-ca8f-4194-8f96-e470dd749dfa|2019-11-06T143122.339686Z|"
                                     "smartseq2_v2.2.0|blessed",
                 TableName.DONOR: "304ba6cd-54dc-489b-a1c8-1dff86e27bdb|hancestro:0016||"
                                  "MONDO:0011273|H syndrome|EFO:0001272|adult|unknown|unknown",
@@ -28,7 +28,7 @@ ETL_TEST_BUNDLES = {
                 TableName.CELL: "2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|"
                                 "1f6aecb3-09a0-432b-bece-d2790da570d6|"
                                 "84dd5dd7-cad0-4874-a36e-d2ca7e9d1489|5f7dee36-68e8-41c8-9e5f-50f3c772176a|"
-                                "e11a1b8b-c83a-419b-bbb7-dc5d214770d0|2019-02-11T171726.073959Z||3859||\n",
+                                "ce00e945-dfc5-495f-ae4b-f0b71aec3d53|2019-11-06T143122.339686Z||3859||\n",
                 TableName.EXPRESSION: "2c748259-d3a5-4a1a-9b1a-c2e0dca6fccc|ENST00000373020|TPM|92.29\n"
             },
             '343dbc5f-bfe8-4f51-b493-a508d017125c': {
@@ -38,8 +38,8 @@ ETL_TEST_BUNDLES = {
                                     "smartseq2_v2.3.0|blessed",
                 TableName.DONOR: "d8ff48d4-7e5a-4b88-a690-3532378d9046|hancestro:0016||"
                                  "MONDO:0011273|H syndrome|EFO:0001272|adult|unknown|unknown",
-                TableName.SPECIMEN: "942ed1bf-d638-4d6c-9953-97deb555604b|d8ff48d4-7e5a-4b88-a690-3532378d9046"
-                                    "UBERON:0002113|kidney|UBERON:0014451|tongue taste bud"
+                TableName.SPECIMEN: "942ed1bf-d638-4d6c-9953-97deb555604b|d8ff48d4-7e5a-4b88-a690-3532378d9046|"
+                                    "UBERON:0002113|kidney|UBERON:0014451|tongue taste bud|"
                                     "MONDO:0011273|H syndrome",
                 TableName.CELL_SUSPENSION: "e584b404-9937-49fe-a323-5e18511f7035|942ed1bf-d638-4d6c-9953-97deb555604b|"
                                            "UBERON:0002113|kidney|UBERON:0014451|tongue taste bud|"


### PR DESCRIPTION
Use new test bundles for integration that don't use deprecated metadata schemas.