### PR TITLE
Update data version from str to int

### DIFF
--- a/matrix/common/aws/dynamo_handler.py
+++ b/matrix/common/aws/dynamo_handler.py
@@ -176,12 +176,12 @@ class DynamoHandler:
             }
         )
 
-    def get_table_item(self, table: DynamoTable, key: str = ""):
+    def get_table_item(self, table: DynamoTable, key: typing.Union[str, int] = ""):
         """Retrieves dynamobdb item corresponding with primary key in the specified table.
 
         Input:
             table: (DynamoTable) enum
-            key: (str) primary key in table
+            key: (str, int) primary key in table
         Output:
             item: dynamodb item
         """

--- a/terraform/modules/matrix-service/infra/dynamo.tf
+++ b/terraform/modules/matrix-service/infra/dynamo.tf
@@ -19,7 +19,7 @@ resource "aws_dynamodb_table" "data_version_table" {
 
   attribute {
     name = "DataVersion"
-    type = "S"
+    type = "N"
   }
 }
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -76,7 +76,7 @@ class MatrixTestCaseUsingMockAWS(unittest.TestCase):
             AttributeDefinitions=[
                 {
                     'AttributeName': "DataVersion",
-                    'AttributeType': "S",
+                    'AttributeType': "N",
                 }
             ],
             ProvisionedThroughput={


### PR DESCRIPTION
Successfully recreated `dcp-matrix-service-data-version-table-<env>` in all environments using `bump_data_version.py`