### PR TITLE
parse unique UUIDs from DB manifest in v0

### DIFF
--- a/matrix/lambdas/daemons/v0/driver.py
+++ b/matrix/lambdas/daemons/v0/driver.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import typing
 
@@ -161,7 +162,7 @@ class Driver:
             return tokens[0]
 
         lines = data.splitlines()[1:]
-        return list(map(_parse_line, lines))
+        return list(collections.OrderedDict.fromkeys(map(_parse_line, lines)))
 
     def _format_and_store_queries_in_s3(self, resolved_bundle_uuids: list, genus_species: str):
         feature_query = feature_query_template.format(self.query_results_bucket,

--- a/tests/unit/lambdas/daemons/test_v0_driver.py
+++ b/tests/unit/lambdas/daemons/test_v0_driver.py
@@ -129,10 +129,18 @@ class TestDriver(unittest.TestCase):
         mock_log_error.assert_called_once_with(error_msg)
 
     def test_parse_download_manifest(self):
-        test_download_manifest = "UUID\tVERSION\nbundle_id_1\tbundle_version_1\nbundle_id_2\tbundle_version_2"
+        with self.subTest("OK"):
+            test_download_manifest = "UUID\tVERSION\nbundle_id_1\tbundle_version_1\nbundle_id_2\tbundle_version_2"
 
-        parsed = self._driver._parse_download_manifest(test_download_manifest)
-        self.assertTrue(parsed, ["bundle_id_1", "bundle_id_2"])
+            parsed = self._driver._parse_download_manifest(test_download_manifest)
+            self.assertEqual(parsed, ["bundle_id_1", "bundle_id_2"])
+
+        with self.subTest("Duplicate rows"):
+            test_download_manifest = "UUID\tVERSION\nbundle_id_1\tbundle_version_1\nbundle_id_2\tbundle_version_2" \
+                                     "\nbundle_id_1\tbundle_version_1"
+
+            parsed = self._driver._parse_download_manifest(test_download_manifest)
+            self.assertEqual(parsed, ["bundle_id_1", "bundle_id_2"])
 
     @mock.patch("matrix.common.aws.sqs_handler.SQSHandler.add_message_to_queue")
     @mock.patch("matrix.common.request.request_tracker.RequestTracker.complete_subtask_execution")


### PR DESCRIPTION
The DB has [updated their file manifest](https://github.com/DataBiosphere/azul/issues/1489) for which now may return duplicate UUIDs. This change handles these cases in order to prevent `resolved bundles in request do not match bundles available in matrix service` errors.